### PR TITLE
Added o365 alias to start the CLI solving #24

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "bin": {
-    "office365": "./dist/index.js"
+    "office365": "./dist/index.js",
+    "o365": "./dist/index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added o365 alias to start the CLI solving #24. The CLI can be now started using both `office365` and `o365`