### PR TITLE
Adds get custom action command #20

### DIFF
--- a/docs/manual/docs/cmd/spo/customaction/customaction-get.md
+++ b/docs/manual/docs/cmd/spo/customaction/customaction-get.md
@@ -1,0 +1,51 @@
+# spo customaction get
+
+Gets information about the specific user custom action for site or site collection
+
+## Usage
+
+```sh
+spo customaction get [options]
+```
+
+## Options
+
+Option|Description
+------|-----------
+`--help`|output usage information
+`-i, --id <id>`|ID of the app to retrieve information for
+`-u, --url <url>`|Url of the site or site collection to retrieve the custom action from
+`-s, --scope [scope]`|Scope of the custom action. Allowed values Site|Web|All. Default All
+`--verbose`|Runs command with verbose logging
+
+!!! important
+    Before using this command, connect to a SharePoint Online site, using the [spo connect](../connect.md) command.
+
+## Remarks
+
+To retrieve custom action, you have to first connect to a SharePoint Online site using the
+[spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
+
+## Examples
+
+```sh
+spo customaction get -i 058140e3-0e37-44fc-a1d3-79c487d371a3 -u https://contoso.sharepoint.com/sites/test
+```
+
+```sh
+spo customaction get --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --url https://contoso.sharepoint.com/sites/test
+```
+
+```sh
+spo customaction get -i 058140e3-0e37-44fc-a1d3-79c487d371a3 -u https://contoso.sharepoint.com/sites/test -s Site
+```
+
+```sh
+spo customaction get --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --url https://contoso.sharepoint.com/sites/test --scope Web
+```
+
+Returns details about the user custom action with ID 'b2307a39-e878-458b-bc90-03bc578531d6' available in the site or site collection.
+
+## More information
+
+- UserCustomAction REST API resources: [https://msdn.microsoft.com/en-us/library/office/dn531432.aspx#bk_UserCustomAction](https://msdn.microsoft.com/en-us/library/office/dn531432.aspx#bk_UserCustomAction)

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -23,6 +23,8 @@ pages:
         - cdn origin set: 'cmd/spo/cdn/cdn-origin-set.md'
         - cdn policy list: 'cmd/spo/cdn/cdn-policy-list.md'
         - cdn policy set: 'cmd/spo/cdn/cdn-policy-set.md'
+      - customaction:
+        - customaction get: 'cmd/spo/customaction/customaction-get.md'
       - storageentity:
         - storageentity get: 'cmd/spo/storageentity/storageentity-get.md'
         - storageentity list: 'cmd/spo/storageentity/storageentity-list.md'

--- a/src/Utils.spec.ts
+++ b/src/Utils.spec.ts
@@ -1,0 +1,17 @@
+import * as assert from 'assert';
+import Utils from './Utils';
+
+describe('Utils', () => {
+
+  it('isValidGuid returns true if valid guid', () => {
+    
+    const result = Utils.isValidGuid('b2307a39-e878-458b-bc90-03bc578531d6');
+    assert(result);
+  });
+
+  it('isValidGuid returns false if invalid guid', () => {
+    
+    const result = Utils.isValidGuid('b2307a39-e878-458b-bc90-03bc578531dw');
+    assert(result == false);
+  });
+});

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -32,4 +32,11 @@ export default class Utils {
       }
     });
   }
+
+  public static isValidGuid(guid: string): boolean {
+    
+    let guidRegEx = new RegExp(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+
+    return guidRegEx.test(guid);
+  }
 }

--- a/src/o365/spo/commands.ts
+++ b/src/o365/spo/commands.ts
@@ -22,5 +22,6 @@ export default {
   CDN_ORIGIN_SET: `${prefix} cdn origin set`,
   CDN_ORIGIN_REMOVE: `${prefix} cdn origin remove`,
   CDN_POLICY_LIST: `${prefix} cdn policy list`,
-  CDN_POLICY_SET: `${prefix} cdn policy set`
+  CDN_POLICY_SET: `${prefix} cdn policy set`,
+  CUSTOMACTION_GET: `${prefix} customaction get`,
 };

--- a/src/o365/spo/commands/customaction/customaction-get.spec.ts
+++ b/src/o365/spo/commands/customaction/customaction-get.spec.ts
@@ -74,7 +74,7 @@ describe(commands.CUSTOMACTION_GET, () => {
 
   it('logs correct telemetry event', (done) => {
     cmdInstance.action = command.action();
-    cmdInstance.action({ options: {}, appCatalogUrl: 'https://contoso-admin.sharepoint.com' }, () => {
+    cmdInstance.action({ options: { verbose: false, url: 'https://contoso.sharepoint.com/sites/appcatalog', id: "abc" }}, () => {
       try {
         assert.equal(telemetry.name, commands.CUSTOMACTION_GET);
         done();
@@ -89,7 +89,7 @@ describe(commands.CUSTOMACTION_GET, () => {
     auth.site = new Site();
     auth.site.connected = false;
     cmdInstance.action = command.action();
-    cmdInstance.action({ options: { verbose: true }, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
+    cmdInstance.action({ options: { verbose: false, url: 'https://contoso.sharepoint.com/sites/appcatalog', id: "abc" }}, () => {
       let returnsCorrectValue: boolean = false;
       log.forEach(l => {
         if (l && l.indexOf('Connect to a SharePoint Online site first') > -1) {
@@ -123,15 +123,13 @@ describe(commands.CUSTOMACTION_GET, () => {
     });
 
     let getRequestSpy = sinon.stub(request, 'get').callsFake((opts) => {
-      
+
       if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
         return Promise.resolve('abc');
       }
 
       if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
-        return Promise.resolve({
-          FormDigestValue: 'abc'
-        });
+        return Promise.resolve('abc');
       }
 
       return Promise.reject('Invalid request');
@@ -143,18 +141,24 @@ describe(commands.CUSTOMACTION_GET, () => {
     cmdInstance.action = command.action();
 
     const getCustomActionSpy = sinon.spy((command as any), 'getCustomAction');
+    const options: Object = {
+      verbose: false,
+      id: 'b2307a39-e878-458b-bc90-03bc578531d6',
+      url: 'https://contoso.sharepoint.com',
+      scope: 'Web'
+    }
 
-    cmdInstance.action({
-      options: {
-        verbose: true,
-        id: 'b2307a39-e878-458b-bc90-03bc578531d6',
-        url: 'https://contoso.sharepoint.com', 
-        scope: 'Web'
-      }
-    }, () => {
+    cmdInstance.action({ options: options }, () => {
 
       try {
         assert(getRequestSpy.calledOnce == true);
+        assert(getCustomActionSpy.calledWith(sinon.match(
+          {
+            id: 'b2307a39-e878-458b-bc90-03bc578531d6',
+            url: 'https://contoso.sharepoint.com',
+            scope: 'Web'
+          }
+        ), cmdInstance));
         assert(getCustomActionSpy.calledOnce == true);
         done();
       }
@@ -186,15 +190,13 @@ describe(commands.CUSTOMACTION_GET, () => {
     });
 
     let getRequestSpy = sinon.stub(request, 'get').callsFake((opts) => {
-      
+
       if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
         return Promise.resolve('abc');
       }
 
       if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
-        return Promise.resolve({
-          FormDigestValue: 'abc'
-        });
+        return Promise.resolve('abc');
       }
 
       return Promise.reject('Invalid request');
@@ -206,18 +208,24 @@ describe(commands.CUSTOMACTION_GET, () => {
     cmdInstance.action = command.action();
 
     const getCustomActionSpy = sinon.spy((command as any), 'getCustomAction');
+    const options: Object = {
+      verbose: false,
+      id: 'b2307a39-e878-458b-bc90-03bc578531d6',
+      url: 'https://contoso.sharepoint.com',
+      scope: 'Site'
+    }
 
-    cmdInstance.action({
-      options: {
-        verbose: true,
-        id: 'b2307a39-e878-458b-bc90-03bc578531d6',
-        url: 'https://contoso.sharepoint.com', 
-        scope: 'Site'
-      }
-    }, () => {
+    cmdInstance.action({ options: options }, () => {
 
       try {
         assert(getRequestSpy.calledOnce == true);
+        assert(getCustomActionSpy.calledWith(sinon.match(
+          {
+            id: 'b2307a39-e878-458b-bc90-03bc578531d6',
+            url: 'https://contoso.sharepoint.com',
+            scope: 'Site'
+          }
+        ), cmdInstance));
         assert(getCustomActionSpy.calledOnce == true);
         done();
       }
@@ -255,9 +263,7 @@ describe(commands.CUSTOMACTION_GET, () => {
       }
 
       if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
-        return Promise.resolve({
-          FormDigestValue: 'abc'
-        });
+        return Promise.resolve('abc');
       }
 
       return Promise.reject('Invalid request');
@@ -272,9 +278,9 @@ describe(commands.CUSTOMACTION_GET, () => {
 
     cmdInstance.action({
       options: {
-        verbose: true,
+        verbose: false,
         id: 'b2307a39-e878-458b-bc90-03bc578531d6',
-        url: 'https://contoso.sharepoint.com', 
+        url: 'https://contoso.sharepoint.com',
         scope: 'All'
       }
     }, () => {
@@ -313,13 +319,11 @@ describe(commands.CUSTOMACTION_GET, () => {
 
     let getRequestSpy = sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
-        return Promise.resolve({"odata.null": true});
+        return Promise.resolve({ "odata.null": true });
       }
 
       if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
-        return Promise.resolve({
-          FormDigestValue: 'abc'
-        });
+        return Promise.resolve('abc');
       }
 
       return Promise.reject('Invalid request');
@@ -356,11 +360,11 @@ describe(commands.CUSTOMACTION_GET, () => {
     });
   });
 
-  it('searchAllScopes called once when scope is All', (done) => {
+  it('searchAllScopes called when scope is All', (done) => {
     sinon.stub(request, 'post').callsFake((opts) => {
 
       if (opts.url.indexOf('/common/oauth2/token') > -1) {
-        return Promise.resolve({'odata.null': true});
+        return Promise.resolve({ 'odata.null': true });
       }
 
       if (opts.url.indexOf('/_api/contextinfo') > -1) {
@@ -379,9 +383,7 @@ describe(commands.CUSTOMACTION_GET, () => {
       }
 
       if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
-        return Promise.resolve({
-          FormDigestValue: 'abc'
-        });
+        return Promise.resolve('abc');
       }
 
       return Promise.reject('Invalid request');
@@ -393,16 +395,21 @@ describe(commands.CUSTOMACTION_GET, () => {
     cmdInstance.action = command.action();
 
     const searchAllScopesSpy = sinon.spy((command as any), 'searchAllScopes');
+    const options: Object = {
+      verbose: false,
+      id: 'b2307a39-e878-458b-bc90-03bc578531d6',
+      url: 'https://contoso.sharepoint.com',
+      scope: "All"
+    }
 
-    cmdInstance.action({
-      options: {
-        verbose: true,
-        id: 'b2307a39-e878-458b-bc90-03bc578531d6',
-        url: 'https://contoso.sharepoint.com'
-      }
-    }, () => {
+    cmdInstance.action({ options: options }, () => {
 
       try {
+        assert(searchAllScopesSpy.calledWith(sinon.match(
+          {
+            id: 'b2307a39-e878-458b-bc90-03bc578531d6',
+            url: 'https://contoso.sharepoint.com'
+          }), cmdInstance));
         assert(searchAllScopesSpy.calledOnce == true);
         done();
       }
@@ -413,6 +420,187 @@ describe(commands.CUSTOMACTION_GET, () => {
         Utils.restore(request.post);
         Utils.restore(request.get);
         Utils.restore((command as any)['searchAllScopes']);
+      }
+    });
+  });
+
+  it('searchAllScopes correctly handles custom action odata.null when All scope specified', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+
+      if (opts.url.indexOf('/common/oauth2/token') > -1) {
+        return Promise.resolve('abc');
+      }
+
+      if (opts.url.indexOf('/_api/contextinfo') > -1) {
+        return Promise.resolve({
+          FormDigestValue: 'abc'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    sinon.stub(request, 'get').callsFake((opts) => {
+
+      if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
+        return Promise.resolve({ "odata.null": true });
+      }
+
+      if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
+        return Promise.resolve({ "odata.null": true });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    const commandLogSpy: any = sinon.spy(cmdInstance, 'log');
+    const actionId: string = 'b2307a39-e878-458b-bc90-03bc578531d6';
+
+    cmdInstance.action({
+      options: {
+        verbose: false,
+        id: actionId,
+        url: 'https://contoso.sharepoint.com',
+        scope: 'All'
+      }
+    }, () => {
+
+      try {
+        assert(commandLogSpy.calledWith(`Custom action with id ${actionId} not found`));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+      finally {
+        Utils.restore(request.post);
+        Utils.restore(request.get);
+        Utils.restore(cmdInstance.log);
+      }
+    });
+  });
+
+  it('searchAllScopes correctly handles web custom action reject request', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+
+      if (opts.url.indexOf('/common/oauth2/token') > -1) {
+        return Promise.resolve('abc');
+      }
+
+      if (opts.url.indexOf('/_api/contextinfo') > -1) {
+        return Promise.resolve({
+          FormDigestValue: 'abc'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const err = 'Invalid request';
+    sinon.stub(request, 'get').callsFake((opts) => {
+
+      if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
+        return Promise.reject(err);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    const commandLogSpy: any = sinon.spy(cmdInstance, 'log');
+    const actionId: string = 'b2307a39-e878-458b-bc90-03bc578531d6';
+
+    cmdInstance.action({
+      options: {
+        verbose: false,
+        id: actionId,
+        url: 'https://contoso.sharepoint.com',
+        scope: 'All'
+      }
+    }, () => {
+
+      try {
+        assert(commandLogSpy.calledWith(sinon.match(err)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+      finally {
+        Utils.restore(request.post);
+        Utils.restore(request.get);
+        Utils.restore(cmdInstance.log);
+      }
+    });
+  });
+
+  it('searchAllScopes correctly handles site custom action reject request', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+
+      if (opts.url.indexOf('/common/oauth2/token') > -1) {
+        return Promise.resolve('abc');
+      }
+
+      if (opts.url.indexOf('/_api/contextinfo') > -1) {
+        return Promise.resolve({
+          FormDigestValue: 'abc'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const err = 'Invalid request';
+    sinon.stub(request, 'get').callsFake((opts) => {
+
+      if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
+        return Promise.resolve({ "odata.null": true });
+      }
+
+      if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
+        return Promise.reject(err);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    const commandLogSpy: any = sinon.spy(cmdInstance, 'log');
+    const actionId: string = 'b2307a39-e878-458b-bc90-03bc578531d6';
+
+    cmdInstance.action({
+      options: {
+        verbose: false,
+        id: actionId,
+        url: 'https://contoso.sharepoint.com',
+        scope: 'All'
+      }
+    }, () => {
+
+      try {
+        assert(commandLogSpy.calledWith(sinon.match(err)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+      finally {
+        Utils.restore(request.post);
+        Utils.restore(request.get);
+        Utils.restore(cmdInstance.log);
       }
     });
   });
@@ -639,7 +827,7 @@ describe(commands.CUSTOMACTION_GET, () => {
       options: {
         id: "BC448D63-484F-49C5-AB8C-96B14AA68D50",
         url: "https://contoso.sharepoint.com",
-        verbose: true
+        verbose: false
       }
     }, () => {
       let containsError = false;

--- a/src/o365/spo/commands/customaction/customaction-get.spec.ts
+++ b/src/o365/spo/commands/customaction/customaction-get.spec.ts
@@ -1,0 +1,662 @@
+import commands from '../../commands';
+import Command, { CommandHelp, CommandValidate, CommandOption } from '../../../../Command';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth, { Site } from '../../SpoAuth';
+const command: Command = require('./customaction-get');
+import * as assert from 'assert';
+import * as request from 'request-promise-native';
+import Utils from '../../../../Utils';
+// import config from '../../../../config';
+
+describe(commands.CUSTOMACTION_GET, () => {
+  let vorpal: Vorpal;
+  let log: string[];
+  let cmdInstance: any;
+  let trackEvent: any;
+  let telemetry: any;
+  let requests: any[];
+
+  before(() => {
+    sinon.stub(auth, 'ensureAccessToken').callsFake(() => { return Promise.resolve('ABC'); });
+    trackEvent = sinon.stub(appInsights, 'trackEvent').callsFake((t) => {
+      telemetry = t;
+    });
+  });
+
+  beforeEach(() => {
+    vorpal = require('../../../../vorpal-init');
+    log = [];
+    cmdInstance = {
+      log: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    auth.site = new Site();
+    telemetry = null;
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      vorpal.find,
+      request.get
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      appInsights.trackEvent,
+      auth.ensureAccessToken,
+      request.get
+    ]);
+  });
+
+  it('has correct name', () => {
+    assert.equal(command.name.startsWith(commands.CUSTOMACTION_GET), true);
+  });
+
+  it('has a description', () => {
+    assert.notEqual(command.description, null);
+  });
+
+  it('calls telemetry', (done) => {
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: {}, appCatalogUrl: 'https://contoso-admin.sharepoint.com' }, () => {
+      try {
+        assert(trackEvent.called);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('logs correct telemetry event', (done) => {
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: {}, appCatalogUrl: 'https://contoso-admin.sharepoint.com' }, () => {
+      try {
+        assert.equal(telemetry.name, commands.CUSTOMACTION_GET);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('aborts when not connected to a SharePoint site', (done) => {
+    auth.site = new Site();
+    auth.site.connected = false;
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { verbose: true }, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
+      let returnsCorrectValue: boolean = false;
+      log.forEach(l => {
+        if (l && l.indexOf('Connect to a SharePoint Online site first') > -1) {
+          returnsCorrectValue = true;
+        }
+      });
+      try {
+        assert(returnsCorrectValue);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('getCustomAction called once when scope is Web', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+
+      if (opts.url.indexOf('/common/oauth2/token') > -1) {
+        return Promise.resolve('abc');
+      }
+
+      if (opts.url.indexOf('/_api/contextinfo') > -1) {
+        return Promise.resolve({
+          FormDigestValue: 'abc'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    let getRequestSpy = sinon.stub(request, 'get').callsFake((opts) => {
+      
+      if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
+        return Promise.resolve('abc');
+      }
+
+      if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
+        return Promise.resolve({
+          FormDigestValue: 'abc'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    const getCustomActionSpy = sinon.spy((command as any), 'getCustomAction');
+
+    cmdInstance.action({
+      options: {
+        verbose: true,
+        id: 'b2307a39-e878-458b-bc90-03bc578531d6',
+        url: 'https://contoso.sharepoint.com', 
+        scope: 'Web'
+      }
+    }, () => {
+
+      try {
+        assert(getRequestSpy.calledOnce == true);
+        assert(getCustomActionSpy.calledOnce == true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+      finally {
+        Utils.restore(request.post);
+        Utils.restore(request.get);
+        Utils.restore((command as any)['getCustomAction']);
+      }
+    });
+  });
+
+  it('getCustomAction called once when scope is Site', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+
+      if (opts.url.indexOf('/common/oauth2/token') > -1) {
+        return Promise.resolve('abc');
+      }
+
+      if (opts.url.indexOf('/_api/contextinfo') > -1) {
+        return Promise.resolve({
+          FormDigestValue: 'abc'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    let getRequestSpy = sinon.stub(request, 'get').callsFake((opts) => {
+      
+      if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
+        return Promise.resolve('abc');
+      }
+
+      if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
+        return Promise.resolve({
+          FormDigestValue: 'abc'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    const getCustomActionSpy = sinon.spy((command as any), 'getCustomAction');
+
+    cmdInstance.action({
+      options: {
+        verbose: true,
+        id: 'b2307a39-e878-458b-bc90-03bc578531d6',
+        url: 'https://contoso.sharepoint.com', 
+        scope: 'Site'
+      }
+    }, () => {
+
+      try {
+        assert(getRequestSpy.calledOnce == true);
+        assert(getCustomActionSpy.calledOnce == true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+      finally {
+        Utils.restore(request.post);
+        Utils.restore(request.get);
+        Utils.restore((command as any)['getCustomAction']);
+      }
+    });
+  });
+
+  it('getCustomAction called once when scope is All, but item found on web level', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+
+      if (opts.url.indexOf('/common/oauth2/token') > -1) {
+        return Promise.resolve('abc');
+      }
+
+      if (opts.url.indexOf('/_api/contextinfo') > -1) {
+        return Promise.resolve({
+          FormDigestValue: 'abc'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    let getRequestSpy = sinon.stub(request, 'get').callsFake((opts) => {
+
+      if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
+        return Promise.resolve('abc');
+      }
+
+      if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
+        return Promise.resolve({
+          FormDigestValue: 'abc'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    const getCustomActionSpy = sinon.spy((command as any), 'getCustomAction');
+
+    cmdInstance.action({
+      options: {
+        verbose: true,
+        id: 'b2307a39-e878-458b-bc90-03bc578531d6',
+        url: 'https://contoso.sharepoint.com', 
+        scope: 'All'
+      }
+    }, () => {
+
+      try {
+        assert(getRequestSpy.calledOnce == true);
+        assert(getCustomActionSpy.calledOnce == true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+      finally {
+        Utils.restore(request.post);
+        Utils.restore(request.get);
+        Utils.restore((command as any)['getCustomAction']);
+      }
+    });
+  });
+
+  it('getCustomAction called twice when scope is All, but item not found on web level', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+
+      if (opts.url.indexOf('/common/oauth2/token') > -1) {
+        return Promise.resolve('abc');
+      }
+
+      if (opts.url.indexOf('/_api/contextinfo') > -1) {
+        return Promise.resolve({
+          FormDigestValue: 'abc'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    let getRequestSpy = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
+        return Promise.resolve({"odata.null": true});
+      }
+
+      if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
+        return Promise.resolve({
+          FormDigestValue: 'abc'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    const getCustomActionSpy = sinon.spy((command as any), 'getCustomAction');
+
+    cmdInstance.action({
+      options: {
+        verbose: true,
+        id: 'b2307a39-e878-458b-bc90-03bc578531d6',
+        url: 'https://contoso.sharepoint.com'
+      }
+    }, () => {
+
+      try {
+        assert(getRequestSpy.calledTwice == true);
+        assert(getCustomActionSpy.calledTwice == true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+      finally {
+        Utils.restore(request.post);
+        Utils.restore(request.get);
+        Utils.restore((command as any)['getCustomAction']);
+      }
+    });
+  });
+
+  it('searchAllScopes called once when scope is All', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+
+      if (opts.url.indexOf('/common/oauth2/token') > -1) {
+        return Promise.resolve({'odata.null': true});
+      }
+
+      if (opts.url.indexOf('/_api/contextinfo') > -1) {
+        return Promise.resolve({
+          FormDigestValue: 'abc'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    sinon.stub(request, 'get').callsFake((opts) => {
+      requests.push(opts);
+      if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
+        return Promise.resolve('abc');
+      }
+
+      if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
+        return Promise.resolve({
+          FormDigestValue: 'abc'
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    const searchAllScopesSpy = sinon.spy((command as any), 'searchAllScopes');
+
+    cmdInstance.action({
+      options: {
+        verbose: true,
+        id: 'b2307a39-e878-458b-bc90-03bc578531d6',
+        url: 'https://contoso.sharepoint.com'
+      }
+    }, () => {
+
+      try {
+        assert(searchAllScopesSpy.calledOnce == true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+      finally {
+        Utils.restore(request.post);
+        Utils.restore(request.get);
+        Utils.restore((command as any)['searchAllScopes']);
+      }
+    });
+  });
+
+  it('supports verbose mode', () => {
+    const options = (command.options() as CommandOption[]);
+    let containsVerboseOption = false;
+    options.forEach(o => {
+      if (o.option === '--verbose') {
+        containsVerboseOption = true;
+      }
+    });
+    assert(containsVerboseOption);
+  });
+
+  it('supports specifying scope', () => {
+    const options = (command.options() as CommandOption[]);
+    let containsScopeOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('[scope]') > -1) {
+        containsScopeOption = true;
+      }
+    });
+    assert(containsScopeOption);
+  });
+
+  it('doesn\'t fail if the parent doesn\'t define options', () => {
+    sinon.stub(Command.prototype, 'options').callsFake(() => { return undefined; });
+    const options = (command.options() as CommandOption[]);
+    Utils.restore(Command.prototype.options);
+    assert(options.length > 0);
+  });
+
+  it('fails validation if the id option not specified', () => {
+    const actual = (command.validate() as CommandValidate)({ options: { url: "https://contoso.sharepoint.com" } });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if the url option not specified', () => {
+    const actual = (command.validate() as CommandValidate)({ options: { id: "BC448D63-484F-49C5-AB8C-96B14AA68D50" } });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if the url option is not a valid SharePoint site URL', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options:
+        {
+          id: "BC448D63-484F-49C5-AB8C-96B14AA68D50",
+          url: 'foo'
+        }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if the id option is not a valid guid', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options:
+        {
+          id: "foo",
+          url: 'https://contoso.sharepoint.com'
+        }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('passes validation when the id and url options specified', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options:
+        {
+          id: "BC448D63-484F-49C5-AB8C-96B14AA68D50",
+          url: "https://contoso.sharepoint.com"
+        }
+    });
+    assert(actual);
+  });
+
+  it('passes validation when the id, url and scope options specified', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options:
+        {
+          id: "BC448D63-484F-49C5-AB8C-96B14AA68D50",
+          url: "https://contoso.sharepoint.com",
+          scope: "Site"
+        }
+    });
+    assert(actual);
+  });
+
+  it('passes validation when the id and url option specified', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options:
+        {
+          id: "BC448D63-484F-49C5-AB8C-96B14AA68D50",
+          url: "https://contoso.sharepoint.com"
+        }
+    });
+    assert(actual);
+  });
+
+  it('humanize scope shows correct value when scope odata is 2', () => {
+    const actual = (command as any)["humanizeScope"](2);
+    assert(actual === "Site");
+  });
+
+  it('humanize scope shows correct value when scope odata is 3', () => {
+    const actual = (command as any)["humanizeScope"](3);
+    assert(actual === "Web");
+  });
+
+  it('humanize scope shows the scope odata value when is different than 2 and 3', () => {
+    const actual = (command as any)["humanizeScope"](1);
+    assert(actual === "1");
+  });
+
+  it('accepts scope to be All', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options:
+        {
+          id: "BC448D63-484F-49C5-AB8C-96B14AA68D50",
+          url: "https://contoso.sharepoint.com",
+          scope: 'All'
+        }
+    });
+    assert(actual);
+  });
+
+  it('accepts scope to be Site', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options:
+        {
+          id: "BC448D63-484F-49C5-AB8C-96B14AA68D50",
+          url: "https://contoso.sharepoint.com",
+          scope: 'Site'
+        }
+    });
+    assert(actual);
+  });
+
+  it('accepts scope to be Web', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options:
+        {
+          id: "BC448D63-484F-49C5-AB8C-96B14AA68D50",
+          url: "https://contoso.sharepoint.com",
+          scope: 'Web'
+        }
+    });
+    assert(actual);
+  });
+
+  it('rejects invalid string scope', () => {
+    const scope = 'foo';
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        id: "BC448D63-484F-49C5-AB8C-96B14AA68D50",
+        url: "https://contoso.sharepoint.com",
+        scope: scope
+      }
+    });
+    assert.equal(actual, `${scope} is not a valid custom action scope. Allowed values are Site|Web|All`);
+  });
+
+  it('rejects invalid scope value specified as number', () => {
+    const scope = 123;
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        id: "BC448D63-484F-49C5-AB8C-96B14AA68D50",
+        url: "https://contoso.sharepoint.com",
+        scope: scope
+      }
+    });
+    assert.equal(actual, `${scope} is not a valid custom action scope. Allowed values are Site|Web|All`);
+  });
+
+  it('doesn\'t fail validation if the optional scope option not specified', () => {
+    const actual = (command.validate() as CommandValidate)(
+      {
+        options:
+          {
+            id: "BC448D63-484F-49C5-AB8C-96B14AA68D50",
+            url: "https://contoso.sharepoint.com"
+          }
+      });
+    assert(actual);
+  });
+
+  it('has help referring to the right command', () => {
+    const _helpLog: string[] = [];
+    const helpLog = (msg: string) => { _helpLog.push(msg); }
+    const cmd: any = {
+      helpInformation: () => { }
+    };
+    const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    (command.help() as CommandHelp)({}, helpLog);
+    assert(find.calledWith(commands.CUSTOMACTION_GET));
+  });
+
+  it('has help with examples', () => {
+    const _log: string[] = [];
+    const log = (msg: string) => { _log.push(msg); }
+    const cmd: any = {
+      helpInformation: () => { }
+    };
+    sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    (command.help() as CommandHelp)({}, log);
+    let containsExamples: boolean = false;
+    _log.forEach(l => {
+      if (l && l.indexOf('Examples:') > -1) {
+        containsExamples = true;
+      }
+    });
+    Utils.restore(vorpal.find);
+    assert(containsExamples);
+  });
+
+  it('correctly handles lack of valid access token', (done) => {
+    Utils.restore(auth.ensureAccessToken);
+    sinon.stub(auth, 'ensureAccessToken').callsFake(() => { return Promise.reject(new Error('Error getting access token')); });
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+    cmdInstance.action({
+      options: {
+        id: "BC448D63-484F-49C5-AB8C-96B14AA68D50",
+        url: "https://contoso.sharepoint.com",
+        verbose: true
+      }
+    }, () => {
+      let containsError = false;
+      log.forEach(l => {
+        if (l &&
+          typeof l === 'string' &&
+          l.indexOf('Error getting access token') > -1) {
+          containsError = true;
+        }
+      });
+      try {
+        assert(containsError);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+});

--- a/src/o365/spo/commands/customaction/customaction-get.spec.ts
+++ b/src/o365/spo/commands/customaction/customaction-get.spec.ts
@@ -14,7 +14,36 @@ describe(commands.CUSTOMACTION_GET, () => {
   let cmdInstance: any;
   let trackEvent: any;
   let telemetry: any;
-  let requests: any[];
+
+  let fakeContextCalls = (): sinon.SinonStub => {
+    return sinon.stub(request, 'post').callsFake((opts) => {
+      
+      if (opts.url.indexOf('/common/oauth2/token') > -1) {
+        return Promise.resolve('abc');
+      }
+
+      if (opts.url.indexOf('/_api/contextinfo') > -1) {
+        return Promise.resolve({
+          FormDigestValue: 'abc'
+        });
+      }
+      return Promise.reject('Invalid request');
+    });
+  }
+
+  let fakeCustomActionRestCalls = (): sinon.SinonStub => {
+    return sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
+        return Promise.resolve('abc');
+      }
+
+      if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
+        return Promise.resolve('abc');
+      }
+
+      return Promise.reject('Invalid request');
+    });
+  }
 
   before(() => {
     sinon.stub(auth, 'ensureAccessToken').callsFake(() => { return Promise.resolve('ABC'); });
@@ -106,32 +135,8 @@ describe(commands.CUSTOMACTION_GET, () => {
   });
 
   it('getCustomAction called once when scope is Web', (done) => {
-    sinon.stub(request, 'post').callsFake((opts) => {
-
-      if (opts.url.indexOf('/common/oauth2/token') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      if (opts.url.indexOf('/_api/contextinfo') > -1) {
-        return Promise.resolve({
-          FormDigestValue: 'abc'
-        });
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    let getRequestSpy = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      return Promise.reject('Invalid request');
-    });
+    fakeContextCalls();
+    let getRequestSpy = fakeCustomActionRestCalls();
 
     auth.site = new Site();
     auth.site.connected = true;
@@ -172,32 +177,8 @@ describe(commands.CUSTOMACTION_GET, () => {
   });
 
   it('getCustomAction called once when scope is Site', (done) => {
-    sinon.stub(request, 'post').callsFake((opts) => {
-
-      if (opts.url.indexOf('/common/oauth2/token') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      if (opts.url.indexOf('/_api/contextinfo') > -1) {
-        return Promise.resolve({
-          FormDigestValue: 'abc'
-        });
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    let getRequestSpy = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      return Promise.reject('Invalid request');
-    });
+    fakeContextCalls();
+    let getRequestSpy = fakeCustomActionRestCalls();
 
     auth.site = new Site();
     auth.site.connected = true;
@@ -238,33 +219,8 @@ describe(commands.CUSTOMACTION_GET, () => {
   });
 
   it('getCustomAction called once when scope is All, but item found on web level', (done) => {
-    sinon.stub(request, 'post').callsFake((opts) => {
-
-      if (opts.url.indexOf('/common/oauth2/token') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      if (opts.url.indexOf('/_api/contextinfo') > -1) {
-        return Promise.resolve({
-          FormDigestValue: 'abc'
-        });
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    let getRequestSpy = sinon.stub(request, 'get').callsFake((opts) => {
-
-      if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      return Promise.reject('Invalid request');
-    });
+    fakeContextCalls();
+    let getRequestSpy = fakeCustomActionRestCalls();
 
     auth.site = new Site();
     auth.site.connected = true;
@@ -299,20 +255,7 @@ describe(commands.CUSTOMACTION_GET, () => {
   });
 
   it('getCustomAction called twice when scope is All, but item not found on web level', (done) => {
-    sinon.stub(request, 'post').callsFake((opts) => {
-
-      if (opts.url.indexOf('/common/oauth2/token') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      if (opts.url.indexOf('/_api/contextinfo') > -1) {
-        return Promise.resolve({
-          FormDigestValue: 'abc'
-        });
-      }
-
-      return Promise.reject('Invalid request');
-    });
+    fakeContextCalls();
 
     let getRequestSpy = sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
@@ -358,33 +301,8 @@ describe(commands.CUSTOMACTION_GET, () => {
   });
 
   it('searchAllScopes called when scope is All', (done) => {
-    sinon.stub(request, 'post').callsFake((opts) => {
-
-      if (opts.url.indexOf('/common/oauth2/token') > -1) {
-        return Promise.resolve({ 'odata.null': true });
-      }
-
-      if (opts.url.indexOf('/_api/contextinfo') > -1) {
-        return Promise.resolve({
-          FormDigestValue: 'abc'
-        });
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    sinon.stub(request, 'get').callsFake((opts) => {
-      requests.push(opts);
-      if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      if (opts.url.indexOf('/_api/Site/UserCustomActions(') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      return Promise.reject('Invalid request');
-    });
+    fakeContextCalls();
+    fakeCustomActionRestCalls();
 
     auth.site = new Site();
     auth.site.connected = true;
@@ -422,20 +340,7 @@ describe(commands.CUSTOMACTION_GET, () => {
   });
 
   it('searchAllScopes correctly handles custom action odata.null when All scope specified', (done) => {
-    sinon.stub(request, 'post').callsFake((opts) => {
-
-      if (opts.url.indexOf('/common/oauth2/token') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      if (opts.url.indexOf('/_api/contextinfo') > -1) {
-        return Promise.resolve({
-          FormDigestValue: 'abc'
-        });
-      }
-
-      return Promise.reject('Invalid request');
-    });
+    fakeContextCalls();
 
     sinon.stub(request, 'get').callsFake((opts) => {
 
@@ -483,20 +388,7 @@ describe(commands.CUSTOMACTION_GET, () => {
   });
 
   it('searchAllScopes correctly handles web custom action reject request', (done) => {
-    sinon.stub(request, 'post').callsFake((opts) => {
-
-      if (opts.url.indexOf('/common/oauth2/token') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      if (opts.url.indexOf('/_api/contextinfo') > -1) {
-        return Promise.resolve({
-          FormDigestValue: 'abc'
-        });
-      }
-
-      return Promise.reject('Invalid request');
-    });
+    fakeContextCalls();
 
     const err = 'Invalid request';
     sinon.stub(request, 'get').callsFake((opts) => {
@@ -541,20 +433,7 @@ describe(commands.CUSTOMACTION_GET, () => {
   });
 
   it('searchAllScopes correctly handles site custom action reject request', (done) => {
-    sinon.stub(request, 'post').callsFake((opts) => {
-
-      if (opts.url.indexOf('/common/oauth2/token') > -1) {
-        return Promise.resolve('abc');
-      }
-
-      if (opts.url.indexOf('/_api/contextinfo') > -1) {
-        return Promise.resolve({
-          FormDigestValue: 'abc'
-        });
-      }
-
-      return Promise.reject('Invalid request');
-    });
+    fakeContextCalls();
 
     const err = 'Invalid request';
     sinon.stub(request, 'get').callsFake((opts) => {
@@ -611,6 +490,64 @@ describe(commands.CUSTOMACTION_GET, () => {
       }
     });
     assert(containsVerboseOption);
+  });
+  
+  it('output printed correctly', (done) => {
+    const actionId: string = "7b115268-c431-458b-9eac-0b22419a1486";
+    const customAction = {
+      ClientSideComponentId: "7b115268-c431-458b-9eac-0b22419a1488",
+      ClientSideComponentProperties: {"prop":1},
+      Id: actionId,
+      Location: "Microsoft.SharePoint.StandardMenu",
+      Name: "abc",
+      Scope: 3
+    }
+    
+    fakeContextCalls();
+    
+    sinon.stub(request, 'get').callsFake((opts) => {
+
+      if (opts.url.indexOf('/_api/Web/UserCustomActions(') > -1) {
+        return Promise.resolve(customAction);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    const logSpy: any = sinon.spy(cmdInstance, 'log');
+
+    cmdInstance.action({
+      options: {
+        verbose: false,
+        id: actionId,
+        url: 'https://contoso.sharepoint.com',
+        scope: 'All'
+      }
+    }, () => {
+
+      try {
+        assert(logSpy.calledWith(sinon.match(customAction.Name)));
+        assert(logSpy.calledWith(sinon.match(customAction.Id)));
+        assert(logSpy.calledWith(sinon.match(customAction.Location)));
+        assert(logSpy.calledWith(sinon.match("Web")));
+        assert(logSpy.calledWith(sinon.match(customAction.ClientSideComponentId)));
+        assert(logSpy.calledWith(sinon.match(JSON.stringify(customAction.ClientSideComponentProperties))));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+      finally {
+        Utils.restore(request.post);
+        Utils.restore(request.get);
+        Utils.restore(logSpy);
+      }
+    });
   });
 
   it('supports specifying scope', () => {
@@ -844,4 +781,4 @@ describe(commands.CUSTOMACTION_GET, () => {
       }
     });
   });
-});
+}); 

--- a/src/o365/spo/commands/customaction/customaction-get.ts
+++ b/src/o365/spo/commands/customaction/customaction-get.ts
@@ -84,7 +84,7 @@ class SpoCustomActionGetCommand extends SpoCommand {
           t.cell('Location', customAction.Location);
           t.cell('Scope', this.humanizeScope(customAction.Scope));
           t.cell('ClientSideComponentId', customAction.ClientSideComponentId);
-          t.cell('ClientSideComponentProperties', customAction.ClientSideComponentProperties);
+          t.cell('ClientSideComponentProperties', JSON.stringify(customAction.ClientSideComponentProperties));
           t.newRow();
   
           cmd.log('');

--- a/src/o365/spo/commands/customaction/customaction-get.ts
+++ b/src/o365/spo/commands/customaction/customaction-get.ts
@@ -60,10 +60,11 @@ class SpoCustomActionGetCommand extends SpoCommand {
         }
 
         if (args.options.scope && args.options.scope.toLowerCase() !== "all") {
-
+          
           return this.getCustomAction(args.options, cmd);
         }
-
+        
+        
         return this.searchAllScopes(args.options, cmd);
       })
       .then((customAction: CustomAction): void => {
@@ -117,8 +118,8 @@ class SpoCustomActionGetCommand extends SpoCommand {
    * another get request is send with `site` scope.
    */
   protected searchAllScopes(options: Options, cmd: CommandInstance): Promise<CustomAction> {
-    return new Promise<CustomAction>((resolve, reject) => {
 
+    return new Promise<CustomAction>((resolve, reject) => {
       options.scope = "Web";
       this.getCustomAction(options, cmd).then((webResult: CustomAction): void => {
 
@@ -150,34 +151,6 @@ class SpoCustomActionGetCommand extends SpoCommand {
         reject(err);
       });
     });
-  }
-
-  /**
-   * This method to be removed when 
-   * https://github.com/waldekmastykarz/office365-cli/commit/c14d6336fa002bd882f2c0d0d220b89ecaeb8bb8 
-   * merged.
-   * @param siteUrl 
-   * @param accessToken 
-   * @param cmd 
-   * @param verbose 
-   */
-  protected getRequestDigestForSite(siteUrl: string, accessToken: string, cmd: CommandInstance, verbose: boolean = false): Promise<ContextInfo> {
-    const requestOptions: any = {
-      url: `${siteUrl}/_api/contextinfo`,
-      headers: {
-        authorization: `Bearer ${accessToken}`,
-        accept: 'application/json;odata=nometadata'
-      },
-      json: true
-    };
-
-    if (verbose) {
-      cmd.log('Executing web request...');
-      cmd.log(requestOptions);
-      cmd.log('');
-    }
-
-    return request.post(requestOptions);
   }
 
   protected humanizeScope(scope: number): string {

--- a/src/o365/spo/commands/customaction/customaction-get.ts
+++ b/src/o365/spo/commands/customaction/customaction-get.ts
@@ -174,7 +174,7 @@ class SpoCustomActionGetCommand extends SpoCommand {
   public options(): CommandOption[] {
     const options: CommandOption[] = [
       {
-        option: '--id <id>',
+        option: '-i, --id <id>',
         description: 'Id (Guid) of the custom action to retrieve'
       },
       {
@@ -230,9 +230,15 @@ class SpoCustomActionGetCommand extends SpoCommand {
       
         Examples:
         
-          ${chalk.grey(config.delimiter)} ${commands.CUSTOMACTION_GET} --id 058140e3-0e37-44fc-a1d3-79c487d371a3 -u https://contoso.sharepoint.com/sites/test
+          ${chalk.grey(config.delimiter)} ${commands.CUSTOMACTION_GET} -i 058140e3-0e37-44fc-a1d3-79c487d371a3 -u https://contoso.sharepoint.com/sites/test
       
-          ${chalk.grey(config.delimiter)} ${commands.CUSTOMACTION_GET} --id 058140e3-0e37-44fc-a1d3-79c487d371a3 -u https://contoso.sharepoint.com/sites/test -s Site
+          ${chalk.grey(config.delimiter)} ${commands.CUSTOMACTION_GET} --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --url https://contoso.sharepoint.com/sites/test
+
+          ${chalk.grey(config.delimiter)} ${commands.CUSTOMACTION_GET} -i 058140e3-0e37-44fc-a1d3-79c487d371a3 -u https://contoso.sharepoint.com/sites/test -s Site
+
+          ${chalk.grey(config.delimiter)} ${commands.CUSTOMACTION_GET} --id 058140e3-0e37-44fc-a1d3-79c487d371a3 --url https://contoso.sharepoint.com/sites/test --scope Web
+            Returns details about the user custom action with ID '058140e3-0e37-44fc-a1d3-79c487d371a3'
+            available in the site or site collection.
       
         More information:
       

--- a/src/o365/spo/commands/customaction/customaction-get.ts
+++ b/src/o365/spo/commands/customaction/customaction-get.ts
@@ -12,6 +12,7 @@ import SpoCommand from '../../SpoCommand';
 import { ContextInfo } from '../../spo';
 import Utils from '../../../../Utils';
 import { CustomAction } from './customaction';
+import Table = require('easy-table');
 
 const vorpal: Vorpal = require('../../../../vorpal-init');
 
@@ -77,12 +78,19 @@ class SpoCustomActionGetCommand extends SpoCommand {
           cmd.log(`Custom action with id ${args.options.id} not found`);
         }
         else {
-          cmd.log(`Details for custom action ${args.options.id}:`);
-          cmd.log(`  Name:     ${customAction.Name}`);
-          cmd.log(`  Location: ${customAction.Location}`);
-          cmd.log(`  Scope:    ${this.humanizeScope(customAction.Scope)}`);
-          cmd.log(`  ClientSideComponentId:    ${customAction.ClientSideComponentId}`);
-          cmd.log(`  ClientSideComponentProperties:    ${customAction.ClientSideComponentProperties}`);
+          const t: Table = new Table();
+          t.cell('Name', customAction.Name);
+          t.cell('Id', customAction.Id);
+          t.cell('Location', customAction.Location);
+          t.cell('Scope', this.humanizeScope(customAction.Scope));
+          t.cell('ClientSideComponentId', customAction.ClientSideComponentId);
+          t.cell('ClientSideComponentProperties', customAction.ClientSideComponentProperties);
+          t.newRow();
+  
+          cmd.log('');
+          cmd.log(t.printTransposed({
+            separator: ': '
+          }));
         }
         cb();
       }, (err: any): void => {

--- a/src/o365/spo/commands/customaction/customaction-get.ts
+++ b/src/o365/spo/commands/customaction/customaction-get.ts
@@ -1,0 +1,160 @@
+import auth from '../../SpoAuth';
+import config from '../../../../config';
+import * as request from 'request-promise-native';
+import commands from '../../commands';
+import VerboseOption from '../../../../VerboseOption';
+import {
+  CommandHelp,
+  CommandOption,
+  CommandValidate
+} from '../../../../Command';
+import SpoCommand from '../../SpoCommand';
+import { ContextInfo } from '../../spo';
+import Utils from '../../../../Utils';
+
+const vorpal: Vorpal = require('../../../../vorpal-init');
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends VerboseOption {
+  id: string;
+  url: string;
+  scope?: string;
+}
+
+class SpoCustomActionGetCommand extends SpoCommand {
+
+  public get name(): string {
+    return `${commands.CUSTOMACTION_GET}`;
+  }
+
+  public get description(): string {
+    return 'Gets details for the specified custom action';
+  }
+
+  public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
+    if (this.verbose) {
+      cmd.log(`Retrieving access token for ${auth.service.resource}...`);
+    }
+
+    auth
+      .ensureAccessToken(auth.service.resource, cmd, this.verbose)
+      .then((accessToken: string): Promise<ContextInfo> => {
+        if (this.verbose) {
+          cmd.log(`Retrieved access token ${accessToken}. Loading details for the ${args.options.id} custom action...`);
+        }
+
+        const requestOptions: any = {
+          url: `${auth.site.url}/_api/web/usercustomactions('${encodeURIComponent(args.options.id)}')`,
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+            accept: 'application/json;odata=nometadata'
+          },
+          json: true
+        };
+
+        if (this.verbose) {
+          cmd.log('Executing web request...');
+          cmd.log(requestOptions);
+          cmd.log('');
+        }
+
+        return request.get(requestOptions);
+      })
+      .then((res: any): void => {  // ContextInfo
+        if (this.verbose) {
+          cmd.log('Response:');
+          cmd.log(res);
+          cmd.log('');
+        }
+
+        cmd.log(`Retrieving custom action...`);
+
+        const json: any = JSON.parse(res); // RestResponse<AppMetadata>
+        cmd.log(json);
+
+        const apps = json.d.results;   
+
+        cmd.log(apps.toString());
+        cb();
+      }, (err: any): void => {
+        cmd.log(vorpal.chalk.red(`Error: ${err}`));
+        cb();
+      });
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '--id <id>',
+        description: 'Id (Guid) of the custom action to retrieve'
+      },
+      {
+        option: '-u, --url <url>',
+        description: 'Url of the site (collection) to retrieve the custom action from'
+      },
+      {
+        option: '-s, --scope [scope]',
+        description: 'Scope of the custom action. Allowed values Site|Web|All. Default All',
+        autocomplete: ['Site', 'Web', 'All']
+      }
+  ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(): CommandValidate {
+    return (args: CommandArgs): boolean | string => {
+
+      if (Utils.isValidGuid(args.options.id) === false) {
+          return `${args.options.id} is not valid. Custom action id (Guid) expected.`;
+      }
+
+      if (SpoCommand.isValidSharePointUrl(args.options.url) === false) {
+        return 'Missing required option url';
+      }
+
+      if (args.options.scope) {
+        if (args.options.scope !== 'Site' &&
+          args.options.scope !== 'Web' &&
+          args.options.scope !== 'All') {
+          return `${args.options.scope} is not a valid custom action scope. Allowed values are Site|Web|All`;
+        }
+      }
+      
+      return true;
+    };
+  }
+
+  public help(): CommandHelp {
+    return function (args: CommandArgs, log: (help: string) => void): void {
+      const chalk = vorpal.chalk;
+      log(vorpal.find(commands.CUSTOMACTION_GET).helpInformation());
+      log(
+        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site,
+        using the ${chalk.blue(commands.CONNECT)} command.
+                      
+        Remarks:
+      
+          To retrieve custom action, you have to first connect to a SharePoint Online site using the
+          ${chalk.blue(commands.CONNECT)} command, eg. ${chalk.grey(`${config.delimiter} ${commands.CONNECT} https://contoso.sharepoint.com`)}.
+      
+        Examples:
+        
+          ${chalk.grey(config.delimiter)} ${commands.CUSTOMACTION_GET} --id 058140e3-0e37-44fc-a1d3-79c487d371a3 -u https://contoso.sharepoint.com/sites/test
+      
+          ${chalk.grey(config.delimiter)} ${commands.CUSTOMACTION_GET} --id 058140e3-0e37-44fc-a1d3-79c487d371a3 -u https://contoso.sharepoint.com/sites/test -s "Site"
+      
+        More information:
+      
+          UserCustomAction REST API resources:
+            https://msdn.microsoft.com/en-us/library/office/dn531432.aspx#bk_UserCustomAction
+      `);
+    };
+  }
+}
+
+module.exports = new SpoCustomActionGetCommand();

--- a/src/o365/spo/commands/customaction/customaction.ts
+++ b/src/o365/spo/commands/customaction/customaction.ts
@@ -1,0 +1,25 @@
+export interface CustomAction {
+   "odata.null": boolean;
+    ClientSideComponentId: string;
+    ClientSideComponentProperties: Object;
+    CommandUIExtension: Object;
+    Description: string;
+    Group: string;
+    Id: string;
+    ImageUrl: string;
+    Location: string;
+    Name: string;
+    RegistrationId: number;
+    RegistrationType: number;
+    Rights: {
+        High: number,
+        Low: number
+    };
+    Scope: number;
+    ScriptBlock: string;
+    ScriptSrc: string;
+    Sequence: number;
+    Title: string;
+    Url: string;
+    VersionOfUserCustomAction: string;
+}


### PR DESCRIPTION
Adds get custom action command resolving issue #20

I tried to keep it up to date with the latest changes.
Didn't know what would be the exact print output when a custom action is found so I made it with the same output we have in the PnP Get-UserCustomAction PowerShell cmdlet with two additional columns:
`
ClientSideComponentId        : 00000000-0000-0000-0000-000000000000
ClientSideComponentProperties: ""
`
so the final output is

```bash
spo customaction get -i 7b115268-c431-458b-9eac-0b22419a1486 -u https://xxx.sharepoint.com/sites/xx -s Web

Name                         : customaction2
Id                           : 7b115268-c431-458b-9eac-0b22419a1486
Location                     : Microsoft.SharePoint.StandardMenu
Scope                        : Web
ClientSideComponentId        : 00000000-0000-0000-0000-000000000000
ClientSideComponentProperties: ""
```

I have no idea how to squash the commits (in VSTS we have lazy checkbox for that, expected it here as well :) ).

Please let me know If any questions.