### PR TITLE
Changed mocha glob to correctly resolve all test files x-plat

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "tsc -p .",
     "watch": "tsc -w -p .",
     "clean": "rimraf ./dist",
-    "test": "nyc -r=lcov -r=text mocha dist/**/*.spec.js"
+    "test": "nyc -r=lcov -r=text mocha \"dist/**/*.spec.js\""
   },
   "keywords": [
     "office 365",


### PR DESCRIPTION
Changed mocha glob in the `npm test` script to correctly resolve all test files x-plat. Previously it would fail if a test was added to the `/src/o365` or `src/auth` folder.