### PR TITLE
Fixed issue with rendering help using --help solving #104

### DIFF
--- a/docs/guides/adding-command.md
+++ b/docs/guides/adding-command.md
@@ -35,7 +35,7 @@ In the **./docs/manual/docs/cmd/[service]** folder, create new file for your com
 
 ## Implement command
 
-Each command in the Office 365 CLI is defined as a class extending the [Command](../../src/Command.ts) base class. At minimum a command must define `name`, `description`, `commandAction` and `help`:
+Each command in the Office 365 CLI is defined as a class extending the [Command](../../src/Command.ts) base class. At minimum a command must define `name`, `description`, `commandAction` and `commandHelp`:
 
 ```ts
 import config from '../../../config';
@@ -61,12 +61,11 @@ class MyCommand extends Command {
     cb(); // notify that the command completed
   }
 
-  public help(): CommandHelp {
-    return function (args: any, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.MYCOMMAND).helpInformation());
-      log(
-        `  Remarks:
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.MYCOMMAND).helpInformation());
+    log(
+      `  Remarks:
 
     Here are some additional considerations when using this command.
 
@@ -75,7 +74,6 @@ class MyCommand extends Command {
     ${chalk.grey(config.delimiter)} ${commands.MYCOMMAND}
       example one of using the command
 `);
-    };
   }
 }
 
@@ -133,11 +131,10 @@ When building command help, you can get the standard help from Vorpal by calling
 ```ts
 class SpoMyCommand extends Command {
   // ...
-  public help(): CommandHelp {
-    return function (args: any, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.MYCOMMAND).helpInformation());
-      log(
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.MYCOMMAND).helpInformation());
+    log(
         `  Remarks:
 
     Here are some additional considerations when using this command.
@@ -147,7 +144,6 @@ class SpoMyCommand extends Command {
     ${chalk.grey(config.delimiter)} ${commands.MYCOMMAND}
       example one of using the command
 `);
-    };
   }
 }
 ```

--- a/src/Command.spec.ts
+++ b/src/Command.spec.ts
@@ -3,7 +3,6 @@ import * as assert from 'assert';
 import Command, {
   CommandValidate,
   CommandCancel,
-  CommandHelp,
   CommandOption,
   CommandTypes
 } from './Command';
@@ -34,9 +33,7 @@ class MockCommand1 extends Command {
   public commandAction(): void {
   }
 
-  public help(): CommandHelp | undefined {
-    return (args: any, log: (help: string) => void) => {
-    };
+  public commandHelp(args: any, log: (message: string) => void): void {
   }
 
   public validate(): CommandValidate | undefined {
@@ -46,7 +43,7 @@ class MockCommand1 extends Command {
   }
 
   public cancel(): CommandCancel | undefined {
-    return () => {};
+    return () => { };
   }
 
   public types(): CommandTypes | undefined {
@@ -73,6 +70,10 @@ class MockCommand2 extends Command {
   }
 
   public commandAction(): void {
+  }
+
+  public commandHelp(args: any, log: (message: string) => void): void {
+    log('MockCommand2 help');
   }
 }
 
@@ -220,14 +221,6 @@ describe('Command', () => {
     assert(helpSpy.calledOnce);
   });
 
-  it('doesn\'t configure help when unavailable', () => {
-    const cmd = new MockCommand2();
-    sinon.stub(vorpal, 'command').callsFake(() => vcmd);
-    cmd.init(vorpal);
-    Utils.restore(vorpal.command);
-    assert(helpSpy.notCalled);
-  });
-
   it('configures types when available', () => {
     const cmd = new MockCommand1();
     sinon.stub(vorpal, 'command').callsFake(() => vcmd);
@@ -248,4 +241,20 @@ describe('Command', () => {
     const cmd = new MockCommand2();
     assert.equal(cmd.getCommandName(), 'Mock command 2');
   });
+
+  it('prints help using the log argument when called from the help command', () => {
+    const sandbox = sinon.createSandbox();
+    sandbox.stub(vorpal, '_command').value({
+      command: 'help mock2'
+    });
+    const log = (msg?: string) => { console.log(msg); };
+    const logSpy = sinon.spy(log);
+    const mock = new MockCommand2();
+    const cmd = {
+      help: mock.help()
+    };
+    cmd.help({}, logSpy);
+    sandbox.restore();
+    assert(logSpy.called);
+  })
 });

--- a/src/o365/spo/SpoCommand.spec.ts
+++ b/src/o365/spo/SpoCommand.spec.ts
@@ -16,6 +16,9 @@ class MockCommand extends SpoCommand {
 
   public commandAction(cmd: CommandInstance, args: {}, cb: () => void): void {
   }
+
+  public commandHelp(args: any, log: (message: string) => void): void {
+  }
 }
 
 describe('SpoCommand', () => {

--- a/src/o365/spo/commands/app/app-add.spec.ts
+++ b/src/o365/spo/commands/app/app-add.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandOption, CommandValidate, CommandError } from '../../../../Command';
+import Command, { CommandOption, CommandValidate, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -417,24 +417,29 @@ describe(commands.APP_ADD, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.APP_ADD));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/app/app-add.ts
+++ b/src/o365/spo/commands/app/app-add.ts
@@ -5,7 +5,6 @@ import * as request from 'request-promise-native';
 import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate
 } from '../../../../Command';
@@ -139,12 +138,11 @@ class SpoAppAddCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.APP_ADD).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site,
+  public commandHelp(args: CommandArgs, log: (message: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.APP_ADD).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site,
   using the ${chalk.blue(commands.CONNECT)} command.
                 
   Remarks:
@@ -172,7 +170,6 @@ class SpoAppAddCommand extends SpoCommand {
     Application Lifecycle Management (ALM) APIs
       https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/app/app-deploy.spec.ts
+++ b/src/o365/spo/commands/app/app-deploy.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandOption, CommandValidate, CommandError } from '../../../../Command';
+import Command, { CommandOption, CommandValidate, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -824,24 +824,29 @@ describe(commands.APP_DEPLOY, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.APP_DEPLOY));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/app/app-deploy.ts
+++ b/src/o365/spo/commands/app/app-deploy.ts
@@ -5,7 +5,6 @@ import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import * as request from 'request-promise-native';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate
 } from '../../../../Command';
@@ -174,12 +173,11 @@ class AppDeployCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.APP_DEPLOY).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint site,
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.APP_DEPLOY).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint site,
         using the ${chalk.blue(commands.CONNECT)} command.
 
   Remarks:
@@ -211,7 +209,6 @@ class AppDeployCommand extends SpoCommand {
     Application Lifecycle Management (ALM) APIs
       https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/app/app-get.spec.ts
+++ b/src/o365/spo/commands/app/app-get.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandOption, CommandValidate, CommandError } from '../../../../Command';
+import Command, { CommandOption, CommandValidate, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -321,24 +321,29 @@ describe(commands.APP_GET, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.APP_GET));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/app/app-get.ts
+++ b/src/o365/spo/commands/app/app-get.ts
@@ -4,7 +4,6 @@ import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import * as request from 'request-promise-native';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate
 } from '../../../../Command';
@@ -97,12 +96,11 @@ class AppGetCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: {}, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.APP_GET).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site,
+  public commandHelp(args: {}, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.APP_GET).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site,
       using the ${chalk.blue(commands.CONNECT)} command.
 
   Remarks:
@@ -122,7 +120,6 @@ class AppGetCommand extends SpoCommand {
     Application Lifecycle Management (ALM) APIs
       https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/app/app-install.spec.ts
+++ b/src/o365/spo/commands/app/app-install.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandOption, CommandValidate, CommandError } from '../../../../Command';
+import Command, { CommandOption, CommandValidate, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -483,24 +483,29 @@ describe(commands.APP_INSTALL, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.APP_INSTALL));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/app/app-install.ts
+++ b/src/o365/spo/commands/app/app-install.ts
@@ -6,7 +6,6 @@ import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import * as request from 'request-promise-native';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate
 } from '../../../../Command';
@@ -122,12 +121,11 @@ class AppInstallCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: {}, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.APP_INSTALL).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site,
+  public commandHelp(args: {}, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.APP_INSTALL).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site,
       using the ${chalk.blue(commands.CONNECT)} command.
 
   Remarks:
@@ -151,7 +149,6 @@ class AppInstallCommand extends SpoCommand {
     Application Lifecycle Management (ALM) APIs
       https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/app/app-list.spec.ts
+++ b/src/o365/spo/commands/app/app-list.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandOption, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -246,24 +246,29 @@ describe(commands.APP_LIST, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.APP_LIST));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/app/app-list.ts
+++ b/src/o365/spo/commands/app/app-list.ts
@@ -2,9 +2,6 @@ import auth from '../../SpoAuth';
 import config from '../../../../config';
 import commands from '../../commands';
 import * as request from 'request-promise-native';
-import {
-  CommandHelp
-} from '../../../../Command';
 import SpoCommand from '../../SpoCommand';
 import { AppMetadata } from './AppMetadata';
 import Utils from '../../../../Utils';
@@ -80,12 +77,11 @@ class AppListCommand extends SpoCommand {
       }, (rawRes: any): void => this.handleRejectedODataPromise(rawRes, cmd, cb));
   }
 
-  public help(): CommandHelp {
-    return function (args: {}, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.APP_LIST).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site, using the ${chalk.blue(commands.CONNECT)} command.
+  public commandHelp(args: {}, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.APP_LIST).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site, using the ${chalk.blue(commands.CONNECT)} command.
    
   Examples:
   
@@ -97,7 +93,6 @@ class AppListCommand extends SpoCommand {
     Application Lifecycle Management (ALM) APIs
       https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/app/app-retract.spec.ts
+++ b/src/o365/spo/commands/app/app-retract.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandOption, CommandValidate, CommandError } from '../../../../Command';
+import Command, { CommandOption, CommandValidate, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -917,24 +917,29 @@ describe(commands.APP_RETRACT, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.APP_RETRACT));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/app/app-retract.ts
+++ b/src/o365/spo/commands/app/app-retract.ts
@@ -5,7 +5,6 @@ import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import * as request from 'request-promise-native';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate
 } from '../../../../Command';
@@ -201,12 +200,11 @@ class AppDeployCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.APP_RETRACT).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint site,
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.APP_RETRACT).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint site,
         using the ${chalk.blue(commands.CONNECT)} command.
 
   Remarks:
@@ -244,7 +242,6 @@ class AppDeployCommand extends SpoCommand {
     Application Lifecycle Management (ALM) APIs
       https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/app/app-uninstall.spec.ts
+++ b/src/o365/spo/commands/app/app-uninstall.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandOption, CommandValidate, CommandError } from '../../../../Command';
+import Command, { CommandOption, CommandValidate, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -591,24 +591,29 @@ describe(commands.APP_UNINSTALL, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.APP_UNINSTALL));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/app/app-uninstall.ts
+++ b/src/o365/spo/commands/app/app-uninstall.ts
@@ -6,7 +6,6 @@ import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import * as request from 'request-promise-native';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate
 } from '../../../../Command';
@@ -154,12 +153,11 @@ class AppUninstallCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: {}, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.APP_UNINSTALL).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site,
+  public commandHelp(args: {}, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.APP_UNINSTALL).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site,
       using the ${chalk.blue(commands.CONNECT)} command.
 
   Remarks:
@@ -182,7 +180,6 @@ class AppUninstallCommand extends SpoCommand {
     Application Lifecycle Management (ALM) APIs
       https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/app/app-upgrade.spec.ts
+++ b/src/o365/spo/commands/app/app-upgrade.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandOption, CommandValidate, CommandError } from '../../../../Command';
+import Command, { CommandOption, CommandValidate, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -434,24 +434,29 @@ describe(commands.APP_UPGRADE, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.APP_UPGRADE));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/app/app-upgrade.ts
+++ b/src/o365/spo/commands/app/app-upgrade.ts
@@ -6,7 +6,6 @@ import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import * as request from 'request-promise-native';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate
 } from '../../../../Command';
@@ -122,12 +121,11 @@ class AppUpgradeCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: {}, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.APP_UPGRADE).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site,
+  public commandHelp(args: {}, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.APP_UPGRADE).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site,
       using the ${chalk.blue(commands.CONNECT)} command.
 
   Remarks:
@@ -146,7 +144,6 @@ class AppUpgradeCommand extends SpoCommand {
     Application Lifecycle Management (ALM) APIs
       https://docs.microsoft.com/en-us/sharepoint/dev/apis/alm-api-for-spfx-add-ins
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/cdn/cdn-get.spec.ts
+++ b/src/o365/spo/commands/cdn/cdn-get.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
 import config from '../../../../config';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
@@ -432,24 +432,29 @@ describe(commands.CDN_GET, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.CDN_GET));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/cdn/cdn-get.ts
+++ b/src/o365/spo/commands/cdn/cdn-get.ts
@@ -5,7 +5,6 @@ import * as request from 'request-promise-native';
 import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate,
   CommandError
@@ -132,12 +131,11 @@ class SpoCdnGetCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.CDN_GET).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.CDN_GET).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
   using the ${chalk.blue(commands.CONNECT)} command.
         
   Remarks:
@@ -163,7 +161,6 @@ class SpoCdnGetCommand extends SpoCommand {
     General availability of Office 365 CDN
       https://dev.office.com/blogs/general-availability-of-office-365-cdn
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/cdn/cdn-origin-list.spec.ts
+++ b/src/o365/spo/commands/cdn/cdn-origin-list.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -399,24 +399,29 @@ describe(commands.CDN_ORIGIN_LIST, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.CDN_ORIGIN_LIST));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/cdn/cdn-origin-list.ts
+++ b/src/o365/spo/commands/cdn/cdn-origin-list.ts
@@ -5,7 +5,6 @@ import * as request from 'request-promise-native';
 import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate,
   CommandError
@@ -133,12 +132,11 @@ class SpoCdnOriginListCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.CDN_ORIGIN_LIST).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.CDN_ORIGIN_LIST).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
   using the ${chalk.blue(commands.CONNECT)} command.
         
   Remarks:
@@ -164,7 +162,6 @@ class SpoCdnOriginListCommand extends SpoCommand {
     General availability of Office 365 CDN
       https://dev.office.com/blogs/general-availability-of-office-365-cdn
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/cdn/cdn-origin-remove.spec.ts
+++ b/src/o365/spo/commands/cdn/cdn-origin-remove.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -454,24 +454,29 @@ describe(commands.CDN_ORIGIN_REMOVE, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.CDN_ORIGIN_REMOVE));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/cdn/cdn-origin-remove.ts
+++ b/src/o365/spo/commands/cdn/cdn-origin-remove.ts
@@ -5,7 +5,6 @@ import * as request from 'request-promise-native';
 import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate,
   CommandError
@@ -172,12 +171,11 @@ class SpoCdnOriginRemoveCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.CDN_ORIGIN_REMOVE).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.CDN_ORIGIN_REMOVE).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
   using the ${chalk.blue(commands.CONNECT)} command.
         
   Remarks:
@@ -200,7 +198,6 @@ class SpoCdnOriginRemoveCommand extends SpoCommand {
     General availability of Office 365 CDN
       https://dev.office.com/blogs/general-availability-of-office-365-cdn
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/cdn/cdn-origin-set.spec.ts
+++ b/src/o365/spo/commands/cdn/cdn-origin-set.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -398,24 +398,29 @@ describe(commands.CDN_ORIGIN_SET, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.CDN_ORIGIN_SET));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/cdn/cdn-origin-set.ts
+++ b/src/o365/spo/commands/cdn/cdn-origin-set.ts
@@ -5,7 +5,6 @@ import * as request from 'request-promise-native';
 import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate,
   CommandError
@@ -141,12 +140,11 @@ class SpoCdnOriginAddCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.CDN_ORIGIN_SET).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.CDN_ORIGIN_SET).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
   using the ${chalk.blue(commands.CONNECT)} command.
         
   Remarks:
@@ -169,7 +167,6 @@ class SpoCdnOriginAddCommand extends SpoCommand {
     General availability of Office 365 CDN
       https://dev.office.com/blogs/general-availability-of-office-365-cdn
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/cdn/cdn-policy-list.spec.ts
+++ b/src/o365/spo/commands/cdn/cdn-policy-list.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -364,24 +364,29 @@ describe(commands.CDN_POLICY_LIST, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.CDN_POLICY_LIST));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/cdn/cdn-policy-list.ts
+++ b/src/o365/spo/commands/cdn/cdn-policy-list.ts
@@ -5,7 +5,6 @@ import * as request from 'request-promise-native';
 import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate,
   CommandError
@@ -142,12 +141,11 @@ class SpoCdnPolicyListCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.CDN_POLICY_LIST).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.CDN_POLICY_LIST).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
   using the ${chalk.blue(commands.CONNECT)} command.
         
   Remarks:
@@ -173,7 +171,6 @@ class SpoCdnPolicyListCommand extends SpoCommand {
     General availability of Office 365 CDN
       https://dev.office.com/blogs/general-availability-of-office-365-cdn
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/cdn/cdn-policy-set.spec.ts
+++ b/src/o365/spo/commands/cdn/cdn-policy-set.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -433,24 +433,29 @@ describe(commands.CDN_POLICY_SET, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.CDN_POLICY_SET));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/cdn/cdn-policy-set.ts
+++ b/src/o365/spo/commands/cdn/cdn-policy-set.ts
@@ -5,7 +5,6 @@ import * as request from 'request-promise-native';
 import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate,
   CommandError
@@ -164,12 +163,11 @@ class SpoCdnPolicySetCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.CDN_POLICY_SET).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.CDN_POLICY_SET).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
   using the ${chalk.blue(commands.CONNECT)} command.
         
   Remarks:
@@ -192,7 +190,6 @@ class SpoCdnPolicySetCommand extends SpoCommand {
     General availability of Office 365 CDN
       https://dev.office.com/blogs/general-availability-of-office-365-cdn
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/cdn/cdn-set.spec.ts
+++ b/src/o365/spo/commands/cdn/cdn-set.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -398,24 +398,29 @@ describe(commands.CDN_SET, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.CDN_SET));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/cdn/cdn-set.ts
+++ b/src/o365/spo/commands/cdn/cdn-set.ts
@@ -5,7 +5,6 @@ import * as request from 'request-promise-native';
 import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate,
   CommandError
@@ -144,12 +143,11 @@ class SpoCdnSetCommand extends SpoCommand {
     return options.concat(parentOptions);
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.CDN_SET).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.CDN_SET).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
   using the ${chalk.blue(commands.CONNECT)} command.
         
   Remarks:
@@ -179,7 +177,6 @@ class SpoCdnSetCommand extends SpoCommand {
     General availability of Office 365 CDN
       https://dev.office.com/blogs/general-availability-of-office-365-cdn
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/connect.ts
+++ b/src/o365/spo/commands/connect.ts
@@ -7,7 +7,6 @@ import commands from '../commands';
 import GlobalOptions from '../../../GlobalOptions';
 import Command, {
   CommandCancel,
-  CommandHelp,
   CommandValidate,
   CommandError
 } from '../../../Command';
@@ -203,12 +202,11 @@ class SpoConnectCommand extends Command {
     }
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.CONNECT).helpInformation());
-      log(
-        `  Arguments:
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.CONNECT).helpInformation());
+    log(
+      `  Arguments:
     
     url  absolute URL of the SharePoint Online site to connect to
         
@@ -239,7 +237,6 @@ class SpoConnectCommand extends Command {
     Connect to a regular SharePoint Online site
       ${chalk.grey(config.delimiter)} ${commands.CONNECT} https://contoso.sharepoint.com/sites/team
 `);
-    }
   }
 }
 

--- a/src/o365/spo/commands/customaction/customaction-get.spec.ts
+++ b/src/o365/spo/commands/customaction/customaction-get.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
@@ -778,24 +778,29 @@ describe(commands.CUSTOMACTION_GET, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.CUSTOMACTION_GET));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (command.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {

--- a/src/o365/spo/commands/customaction/customaction-get.ts
+++ b/src/o365/spo/commands/customaction/customaction-get.ts
@@ -4,7 +4,6 @@ import * as request from 'request-promise-native';
 import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate
 } from '../../../../Command';
@@ -205,12 +204,11 @@ class SpoCustomActionGetCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.CUSTOMACTION_GET).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site,
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.CUSTOMACTION_GET).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site,
         using the ${chalk.blue(commands.CONNECT)} command.
                       
   Remarks:
@@ -241,7 +239,6 @@ class SpoCustomActionGetCommand extends SpoCommand {
     UserCustomAction REST API resources:
       https://msdn.microsoft.com/en-us/library/office/dn531432.aspx#bk_UserCustomAction
       `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/disconnect.spec.ts
+++ b/src/o365/spo/commands/disconnect.spec.ts
@@ -1,9 +1,9 @@
 import commands from '../commands';
-import Command, { CommandHelp } from '../../../Command';
+import Command from '../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../appInsights';
 import auth, { Site } from '../SpoAuth';
-const disconnectCommand: Command = require('./disconnect');
+const command: Command = require('./disconnect');
 import * as assert from 'assert';
 import Utils from '../../../Utils';
 
@@ -44,15 +44,15 @@ describe(commands.DISCONNECT, () => {
   });
 
   it('has correct name', () => {
-    assert.equal(disconnectCommand.name.startsWith(commands.DISCONNECT), true);
+    assert.equal(command.name.startsWith(commands.DISCONNECT), true);
   });
 
   it('has a description', () => {
-    assert.notEqual(disconnectCommand.description, null);
+    assert.notEqual(command.description, null);
   });
 
   it('calls telemetry', (done) => {
-    cmdInstance.action = disconnectCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: {} }, () => {
       try {
         assert(trackEvent.called);
@@ -65,7 +65,7 @@ describe(commands.DISCONNECT, () => {
   });
 
   it('logs correct telemetry event', (done) => {
-    cmdInstance.action = disconnectCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: {} }, () => {
       try {
         assert.equal(telemetry.name, commands.DISCONNECT);
@@ -80,7 +80,7 @@ describe(commands.DISCONNECT, () => {
   it('disconnects from SharePoint when connected', (done) => {
     auth.site = new Site();
     auth.site.connected = true;
-    cmdInstance.action = disconnectCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true } }, () => {
       try {
         assert(!auth.site.connected);
@@ -95,7 +95,7 @@ describe(commands.DISCONNECT, () => {
   it('disconnects from SharePoint when not connected', (done) => {
     auth.site = new Site();
     auth.site.connected = false;
-    cmdInstance.action = disconnectCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true } }, () => {
       try {
         assert(!auth.site.connected);
@@ -110,7 +110,7 @@ describe(commands.DISCONNECT, () => {
   it('clears persisted connection info when disconnecting', (done) => {
     auth.site = new Site();
     auth.site.connected = true;
-    cmdInstance.action = disconnectCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true } }, () => {
       try {
         assert(authClearSiteConnectionInfoStub.called);
@@ -123,32 +123,37 @@ describe(commands.DISCONNECT, () => {
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (disconnectCommand.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.DISCONNECT));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (disconnectCommand.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {
         containsExamples = true;
       }
     });
-    assert(containsExamples);
     Utils.restore(vorpal.find);
+    assert(containsExamples);
   });
 
   it('correctly handles error while clearing persisted connection info', (done) => {
@@ -157,7 +162,7 @@ describe(commands.DISCONNECT, () => {
     auth.site = new Site();
     const disconnectSpy = sinon.spy(auth.site, 'disconnect');
     auth.site.connected = true;
-    cmdInstance.action = disconnectCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: false } }, () => {
       try {
         assert(disconnectSpy.called);
@@ -177,7 +182,7 @@ describe(commands.DISCONNECT, () => {
     auth.site = new Site();
     const disconnectSpy = sinon.spy(auth.site, 'disconnect');
     auth.site.connected = true;
-    cmdInstance.action = disconnectCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true } }, () => {
       try {
         assert(disconnectSpy.called);

--- a/src/o365/spo/commands/disconnect.ts
+++ b/src/o365/spo/commands/disconnect.ts
@@ -2,7 +2,7 @@ import auth from '../SpoAuth';
 import commands from '../commands';
 import config from '../../../config';
 import Command, {
-  CommandHelp, CommandError,
+  CommandError,
 } from '../../../Command';
 import appInsights from '../../../appInsights';
 
@@ -47,12 +47,11 @@ class SpoDisconnectCommand extends Command {
       });
   }
 
-  public help(): CommandHelp {
-    return function (args: any, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.DISCONNECT).helpInformation());
-      log(
-        `  Remarks:
+  public commandHelp(args: any, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.DISCONNECT).helpInformation());
+    log(
+      `  Remarks:
 
     The ${chalk.blue(commands.DISCONNECT)} command disconnects from the previously connected
     SharePoint Online site and removes any access and refresh tokens from memory.
@@ -66,7 +65,6 @@ class SpoDisconnectCommand extends Command {
     debug mode including detailed debug information in the console output
       ${chalk.grey(config.delimiter)} ${commands.DISCONNECT} --debug
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/status.ts
+++ b/src/o365/spo/commands/status.ts
@@ -2,7 +2,7 @@ import auth from '../SpoAuth';
 import config from '../../../config';
 import commands from '../commands';
 import Command, {
-  CommandHelp, CommandError
+  CommandError
 } from '../../../Command';
 
 const vorpal: Vorpal = require('../../../vorpal-init');
@@ -58,12 +58,11 @@ class SpoStatusCommand extends Command {
       });
   }
 
-  public help(): CommandHelp {
-    return function (args: any, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.STATUS).helpInformation());
-      log(
-        `  Remarks:
+  public commandHelp(args: any, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.STATUS).helpInformation());
+    log(
+      `  Remarks:
 
     If you are connected to a SharePoint Online, the ${chalk.blue(commands.STATUS)} command
     will show you information about the site to which you are connected, the currently stored
@@ -74,7 +73,6 @@ class SpoStatusCommand extends Command {
     Show the information about the current connection to SharePoint Online
       ${chalk.grey(config.delimiter)} ${commands.STATUS}
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/storageentity/storageentity-get.spec.ts
+++ b/src/o365/spo/commands/storageentity/storageentity-get.spec.ts
@@ -1,9 +1,9 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandOption, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
-const storageEntityGetCommand: Command = require('./storageentity-get');
+const command: Command = require('./storageentity-get');
 import * as assert from 'assert';
 import * as request from 'request-promise-native';
 import Utils from '../../../../Utils';
@@ -99,15 +99,15 @@ describe(commands.STORAGEENTITY_GET, () => {
   });
 
   it('has correct name', () => {
-    assert.equal(storageEntityGetCommand.name.startsWith(commands.STORAGEENTITY_GET), true);
+    assert.equal(command.name.startsWith(commands.STORAGEENTITY_GET), true);
   });
 
   it('has a description', () => {
-    assert.notEqual(storageEntityGetCommand.description, null);
+    assert.notEqual(command.description, null);
   });
 
   it('calls telemetry', (done) => {
-    cmdInstance.action = storageEntityGetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: {}, appCatalogUrl: 'https://contoso-admin.sharepoint.com' }, () => {
       try {
         assert(trackEvent.called);
@@ -120,7 +120,7 @@ describe(commands.STORAGEENTITY_GET, () => {
   });
 
   it('logs correct telemetry event', (done) => {
-    cmdInstance.action = storageEntityGetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: {}, appCatalogUrl: 'https://contoso-admin.sharepoint.com' }, () => {
       try {
         assert.equal(telemetry.name, commands.STORAGEENTITY_GET);
@@ -135,7 +135,7 @@ describe(commands.STORAGEENTITY_GET, () => {
   it('aborts when not connected to a SharePoint site', (done) => {
     auth.site = new Site();
     auth.site.connected = false;
-    cmdInstance.action = storageEntityGetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true }, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith(new CommandError('Connect to a SharePoint Online site first')));
@@ -151,7 +151,7 @@ describe(commands.STORAGEENTITY_GET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityGetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, key: 'existingproperty' }, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith({
@@ -172,7 +172,7 @@ describe(commands.STORAGEENTITY_GET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityGetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, key: 'propertywithoutdescription' }, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith({
@@ -193,7 +193,7 @@ describe(commands.STORAGEENTITY_GET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityGetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: false, key: 'propertywithoutcomments' }, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith({
@@ -214,7 +214,7 @@ describe(commands.STORAGEENTITY_GET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityGetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: false, key: 'nonexistingproperty' }, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
       try {
         assert.equal(log.length, 0);
@@ -230,7 +230,7 @@ describe(commands.STORAGEENTITY_GET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityGetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, key: 'nonexistingproperty' }, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
       let correctValue: boolean = false;
       log.forEach(l => {
@@ -254,7 +254,7 @@ describe(commands.STORAGEENTITY_GET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityGetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, key: '#myprop' }, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith({
@@ -272,7 +272,7 @@ describe(commands.STORAGEENTITY_GET, () => {
   });
 
   it('supports debug mode', () => {
-    const options = (storageEntityGetCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     let containsdebugOption = false;
     options.forEach(o => {
       if (o.option === '--debug') {
@@ -283,7 +283,7 @@ describe(commands.STORAGEENTITY_GET, () => {
   });
 
   it('requires tenant property name', () => {
-    const options = (storageEntityGetCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     let requiresTenantPropertyName = false;
     options.forEach(o => {
       if (o.option.indexOf('<key>') > -1) {
@@ -295,30 +295,35 @@ describe(commands.STORAGEENTITY_GET, () => {
 
   it('doesn\'t fail if the parent doesn\'t define options', () => {
     sinon.stub(Command.prototype, 'options').callsFake(() => { return undefined; });
-    const options = (storageEntityGetCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     Utils.restore(Command.prototype.options);
     assert(options.length > 0);
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (storageEntityGetCommand.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.STORAGEENTITY_GET));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (storageEntityGetCommand.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {
@@ -335,7 +340,7 @@ describe(commands.STORAGEENTITY_GET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityGetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true }, appCatalogUrl: 'https://contoso-admin.sharepoint.com' }, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith(new CommandError('Error getting access token')));

--- a/src/o365/spo/commands/storageentity/storageentity-get.ts
+++ b/src/o365/spo/commands/storageentity/storageentity-get.ts
@@ -4,7 +4,6 @@ import * as request from 'request-promise-native';
 import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import {
-  CommandHelp,
   CommandOption
 } from '../../../../Command';
 import SpoCommand from '../../SpoCommand';
@@ -93,12 +92,11 @@ class SpoStorageEntityGetCommand extends SpoCommand {
     return options.concat(parentOptions);
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.STORAGEENTITY_GET).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site using the
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.STORAGEENTITY_GET).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site using the
         ${chalk.blue(commands.CONNECT)} command.
         
   Remarks:
@@ -120,7 +118,6 @@ class SpoStorageEntityGetCommand extends SpoCommand {
     SharePoint Framework Tenant Properties
       https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/storageentity/storageentity-list.spec.ts
+++ b/src/o365/spo/commands/storageentity/storageentity-list.spec.ts
@@ -1,9 +1,9 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
-const storageEntityListCommand: Command = require('./storageentity-list');
+const command: Command = require('./storageentity-list');
 import * as assert from 'assert';
 import * as request from 'request-promise-native';
 import Utils from '../../../../Utils';
@@ -53,15 +53,15 @@ describe(commands.STORAGEENTITY_LIST, () => {
   });
 
   it('has correct name', () => {
-    assert.equal(storageEntityListCommand.name.startsWith(commands.STORAGEENTITY_LIST), true);
+    assert.equal(command.name.startsWith(commands.STORAGEENTITY_LIST), true);
   });
 
   it('has a description', () => {
-    assert.notEqual(storageEntityListCommand.description, null);
+    assert.notEqual(command.description, null);
   });
 
   it('calls telemetry', (done) => {
-    cmdInstance.action = storageEntityListCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: {}, appCatalogUrl: 'https://contoso-admin.sharepoint.com' }, () => {
       try {
         assert(trackEvent.called);
@@ -74,7 +74,7 @@ describe(commands.STORAGEENTITY_LIST, () => {
   });
 
   it('logs correct telemetry event', (done) => {
-    cmdInstance.action = storageEntityListCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: {}, appCatalogUrl: 'https://contoso-admin.sharepoint.com' }, () => {
       try {
         assert.equal(telemetry.name, commands.STORAGEENTITY_LIST);
@@ -89,7 +89,7 @@ describe(commands.STORAGEENTITY_LIST, () => {
   it('aborts when not connected to a SharePoint site', (done) => {
     auth.site = new Site();
     auth.site.connected = false;
-    cmdInstance.action = storageEntityListCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true }, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith(new CommandError('Connect to a SharePoint Online site first')));
@@ -129,7 +129,7 @@ describe(commands.STORAGEENTITY_LIST, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityListCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }}, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith([
@@ -171,7 +171,7 @@ describe(commands.STORAGEENTITY_LIST, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityListCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: false, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }}, () => {
       try {
         assert.equal(log.length, 0);
@@ -200,7 +200,7 @@ describe(commands.STORAGEENTITY_LIST, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityListCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }}, () => {
       let correctResponse: boolean = false;
       log.forEach(l => {
@@ -239,7 +239,7 @@ describe(commands.STORAGEENTITY_LIST, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityListCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: false, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }}, () => {
       try {
         assert.equal(log.length, 0);
@@ -268,7 +268,7 @@ describe(commands.STORAGEENTITY_LIST, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityListCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }}, () => {
       let correctResponse: boolean = false;
       log.forEach(l => {
@@ -307,7 +307,7 @@ describe(commands.STORAGEENTITY_LIST, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityListCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }}, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith(new CommandError('Unexpected token a in JSON at position 0')));
@@ -320,7 +320,7 @@ describe(commands.STORAGEENTITY_LIST, () => {
   });
 
   it('supports debug mode', () => {
-    const options = (storageEntityListCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     let containsdebugOption = false;
     options.forEach(o => {
       if (o.option === '--debug') {
@@ -331,7 +331,7 @@ describe(commands.STORAGEENTITY_LIST, () => {
   });
 
   it('requires app catalog URL', () => {
-    const options = (storageEntityListCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     let requiresAppCatalogUrl = false;
     options.forEach(o => {
       if (o.option.indexOf('<appCatalogUrl>') > -1) {
@@ -343,51 +343,56 @@ describe(commands.STORAGEENTITY_LIST, () => {
 
   it('doesn\'t fail if the parent doesn\'t define options', () => {
     sinon.stub(Command.prototype, 'options').callsFake(() => { return undefined; });
-    const options = (storageEntityListCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     Utils.restore(Command.prototype.options);
     assert(options.length > 0);
   });
 
   it('accepts valid SharePoint Online app catalog URL', () => {
-    const actual = (storageEntityListCommand.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }});
+    const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }});
     assert(actual);
   });
 
   it('accepts valid SharePoint Online site URL', () => {
-    const actual = (storageEntityListCommand.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com' }});
+    const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com' }});
     assert(actual);
   });
 
   it('rejects invalid SharePoint Online URL', () => {
     const url = 'https://contoso.com';
-    const actual = (storageEntityListCommand.validate() as CommandValidate)({ options: { appCatalogUrl: url }});
+    const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: url }});
     assert.equal(actual, `${url} is not a valid SharePoint Online site URL`);
   });
 
   it('fails validation when no SharePoint Online app catalog URL specified', () => {
-    const actual = (storageEntityListCommand.validate() as CommandValidate)({ options: { }});
+    const actual = (command.validate() as CommandValidate)({ options: { }});
     assert.equal(actual, 'Missing required option appCatalogUrl');
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (storageEntityListCommand.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.STORAGEENTITY_LIST));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (storageEntityListCommand.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {
@@ -404,7 +409,7 @@ describe(commands.STORAGEENTITY_LIST, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityListCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, appCatalogUrl: 'https://contoso-admin.sharepoint.com' }}, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith(new CommandError('Error getting access token')));

--- a/src/o365/spo/commands/storageentity/storageentity-list.ts
+++ b/src/o365/spo/commands/storageentity/storageentity-list.ts
@@ -5,7 +5,6 @@ import * as request from 'request-promise-native';
 import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate
 } from '../../../../Command';
@@ -133,12 +132,11 @@ class SpoStorageEntityListCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.STORAGEENTITY_LIST).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site using the
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.STORAGEENTITY_LIST).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site using the
   ${chalk.blue(commands.CONNECT)} command.
         
   Remarks:
@@ -160,7 +158,6 @@ class SpoStorageEntityListCommand extends SpoCommand {
     SharePoint Framework Tenant Properties
       https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/storageentity/storageentity-remove.spec.ts
+++ b/src/o365/spo/commands/storageentity/storageentity-remove.spec.ts
@@ -1,9 +1,9 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
-const storageEntityRemoveCommand: Command = require('./storageentity-remove');
+const command: Command = require('./storageentity-remove');
 import * as assert from 'assert';
 import * as request from 'request-promise-native';
 import config from '../../../../config';
@@ -85,15 +85,15 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
   });
 
   it('has correct name', () => {
-    assert.equal(storageEntityRemoveCommand.name.startsWith(commands.STORAGEENTITY_REMOVE), true);
+    assert.equal(command.name.startsWith(commands.STORAGEENTITY_REMOVE), true);
   });
 
   it('has a description', () => {
-    assert.notEqual(storageEntityRemoveCommand.description, null);
+    assert.notEqual(command.description, null);
   });
 
   it('calls telemetry', (done) => {
-    cmdInstance.action = storageEntityRemoveCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: {}, url: 'https://contoso-admin.sharepoint.com' }, () => {
       try {
         assert(trackEvent.called);
@@ -106,7 +106,7 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
   });
 
   it('logs correct telemetry event', (done) => {
-    cmdInstance.action = storageEntityRemoveCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: {}, url: 'https://contoso-admin.sharepoint.com' }, () => {
       try {
         assert.equal(telemetry.name, commands.STORAGEENTITY_REMOVE);
@@ -121,7 +121,7 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
   it('aborts when not connected to a SharePoint site', (done) => {
     auth.site = new Site();
     auth.site.connected = false;
-    cmdInstance.action = storageEntityRemoveCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true }, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith(new CommandError('Connect to a SharePoint Online site first')));
@@ -137,7 +137,7 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso.sharepoint.com';
-    cmdInstance.action = storageEntityRemoveCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true }, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith(new CommandError(`${auth.site.url} is not a tenant admin site. Connect to your tenant admin site and try again`)));
@@ -153,7 +153,7 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityRemoveCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: false, key: 'existingproperty', confirm: true, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }}, () => {
       let deleteRequestIssued = false;
       requests.forEach(r => {
@@ -180,7 +180,7 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityRemoveCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, key: 'existingproperty', appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }}, () => {
       let promptIssued = false;
 
@@ -202,7 +202,7 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityRemoveCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.prompt = (options: any, cb: (result: { continue: boolean }) => void) => {
       cb({ continue: false });
     };
@@ -221,7 +221,7 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityRemoveCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.prompt = (options: any, cb: (result: { continue: boolean }) => void) => {
       cb({ continue: true });
     };
@@ -283,7 +283,7 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityRemoveCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.prompt = (options: any, cb: (result: { continue: boolean }) => void) => {
       cb({ continue: true });
     };
@@ -307,7 +307,7 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
   });
 
   it('supports debug mode', () => {
-    const options = (storageEntityRemoveCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     let containsdebugOption = false;
     options.forEach(o => {
       if (o.option === '--debug') {
@@ -318,7 +318,7 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
   });
 
   it('requires app catalog URL', () => {
-    const options = (storageEntityRemoveCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     let requiresAppCatalogUrl = false;
     options.forEach(o => {
       if (o.option.indexOf('<appCatalogUrl>') > -1) {
@@ -329,7 +329,7 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
   });
 
   it('supports suppressing confirmation prompt', () => {
-    const options = (storageEntityRemoveCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     let containsConfirmOption = false;
     options.forEach(o => {
       if (o.option.indexOf('--confirm') > -1) {
@@ -340,7 +340,7 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
   });
 
   it('requires tenant property name', () => {
-    const options = (storageEntityRemoveCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     let requiresTenantPropertyName = false;
     options.forEach(o => {
       if (o.option.indexOf('<key>') > -1) {
@@ -352,51 +352,56 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
 
   it('doesn\'t fail if the parent doesn\'t define options', () => {
     sinon.stub(Command.prototype, 'options').callsFake(() => { return undefined; });
-    const options = (storageEntityRemoveCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     Utils.restore(Command.prototype.options);
     assert(options.length > 0);
   });
 
   it('accepts valid SharePoint Online app catalog URL', () => {
-    const actual = (storageEntityRemoveCommand.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }});
+    const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }});
     assert(actual);
   });
 
   it('accepts valid SharePoint Online site URL', () => {
-    const actual = (storageEntityRemoveCommand.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com' }});
+    const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com' }});
     assert(actual);
   });
 
   it('rejects invalid SharePoint Online URL', () => {
     const url = 'https://contoso.com';
-    const actual = (storageEntityRemoveCommand.validate() as CommandValidate)({ options: { appCatalogUrl: url }});
+    const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: url }});
     assert.equal(actual, `${url} is not a valid SharePoint Online site URL`);
   });
 
   it('fails validation when no SharePoint Online app catalog URL specified', () => {
-    const actual = (storageEntityRemoveCommand.validate() as CommandValidate)({ options: { }});
+    const actual = (command.validate() as CommandValidate)({ options: { }});
     assert.equal(actual, 'Missing required option appCatalogUrl');
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (storageEntityRemoveCommand.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.STORAGEENTITY_REMOVE));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (storageEntityRemoveCommand.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {
@@ -413,7 +418,7 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntityRemoveCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, confirm: true, key: 'existingproperty', appCatalogUrl: 'https://contoso-admin.sharepoint.com' }}, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith(new CommandError('Error getting access token')));

--- a/src/o365/spo/commands/storageentity/storageentity-remove.ts
+++ b/src/o365/spo/commands/storageentity/storageentity-remove.ts
@@ -5,7 +5,6 @@ import * as request from 'request-promise-native';
 import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate,
   CommandError
@@ -156,12 +155,11 @@ class SpoStorageEntityRemoveCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.STORAGEENTITY_REMOVE).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.STORAGEENTITY_REMOVE).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
   using the ${chalk.blue(commands.CONNECT)} command.
                 
   Remarks:
@@ -189,7 +187,6 @@ class SpoStorageEntityRemoveCommand extends SpoCommand {
     SharePoint Framework Tenant Properties
       https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties
 `);
-    };
   }
 }
 

--- a/src/o365/spo/commands/storageentity/storageentity-set.spec.ts
+++ b/src/o365/spo/commands/storageentity/storageentity-set.spec.ts
@@ -1,9 +1,9 @@
 import commands from '../../commands';
-import Command, { CommandHelp, CommandValidate, CommandOption, CommandError } from '../../../../Command';
+import Command, { CommandValidate, CommandOption, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth, { Site } from '../../SpoAuth';
-const storageEntitySetCommand: Command = require('./storageentity-set');
+const command: Command = require('./storageentity-set');
 import * as assert from 'assert';
 import * as request from 'request-promise-native';
 import config from '../../../../config';
@@ -79,15 +79,15 @@ describe(commands.STORAGEENTITY_SET, () => {
   });
 
   it('has correct name', () => {
-    assert.equal(storageEntitySetCommand.name.startsWith(commands.STORAGEENTITY_SET), true);
+    assert.equal(command.name.startsWith(commands.STORAGEENTITY_SET), true);
   });
 
   it('has a description', () => {
-    assert.notEqual(storageEntitySetCommand.description, null);
+    assert.notEqual(command.description, null);
   });
 
   it('calls telemetry', (done) => {
-    cmdInstance.action = storageEntitySetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: {}, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
       try {
         assert(trackEvent.called);
@@ -100,7 +100,7 @@ describe(commands.STORAGEENTITY_SET, () => {
   });
 
   it('logs correct telemetry event', (done) => {
-    cmdInstance.action = storageEntitySetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: {}, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
       try {
         assert.equal(telemetry.name, commands.STORAGEENTITY_SET);
@@ -115,7 +115,7 @@ describe(commands.STORAGEENTITY_SET, () => {
   it('aborts when not connected to a SharePoint site', (done) => {
     auth.site = new Site();
     auth.site.connected = false;
-    cmdInstance.action = storageEntitySetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true }, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith(new CommandError('Connect to a SharePoint Online site first')));
@@ -131,7 +131,7 @@ describe(commands.STORAGEENTITY_SET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso.sharepoint.com';
-    cmdInstance.action = storageEntitySetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true }, appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith(new CommandError(`${auth.site.url} is not a tenant admin site. Connect to your tenant admin site and try again`)));
@@ -147,7 +147,7 @@ describe(commands.STORAGEENTITY_SET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntitySetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, key: 'Property1', value: 'Lorem', description: 'ipsum', comment: 'dolor', appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } }, () => {
       let setRequestIssued = false;
       requests.forEach(r => {
@@ -201,7 +201,7 @@ describe(commands.STORAGEENTITY_SET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntitySetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: false, key: 'Property1', value: 'Lorem', appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } }, () => {
       try {
         assert.equal(log.length, 0);
@@ -244,7 +244,7 @@ describe(commands.STORAGEENTITY_SET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntitySetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, key: 'Property1', value: 'Lorem', appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } }, () => {
       let isDone = false;
       log.forEach(l => {
@@ -294,7 +294,7 @@ describe(commands.STORAGEENTITY_SET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntitySetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, key: '<Property1>', value: '\'Lorem\'', description: '"ipsum"', comment: '<dolor & samet>', appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } }, () => {
       let isDone = false;
       log.forEach(l => {
@@ -350,7 +350,7 @@ describe(commands.STORAGEENTITY_SET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntitySetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: false, key: 'Property1', value: 'Lorem', description: 'ipsum', comment: 'dolor', appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } }, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith(new CommandError('An error has occurred')));
@@ -401,7 +401,7 @@ describe(commands.STORAGEENTITY_SET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntitySetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, key: 'Property1', value: 'Lorem', description: 'ipsum', comment: 'dolor', appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } }, () => {
       let accessDeniedErrorHandled = false;
       log.forEach(l => {
@@ -424,7 +424,7 @@ describe(commands.STORAGEENTITY_SET, () => {
   });
 
   it('supports debug mode', () => {
-    const options = (storageEntitySetCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     let containsdebugOption = false;
     options.forEach(o => {
       if (o.option === '--debug') {
@@ -435,7 +435,7 @@ describe(commands.STORAGEENTITY_SET, () => {
   });
 
   it('requires app catalog URL', () => {
-    const options = (storageEntitySetCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     let requiresAppCatalogUrl = false;
     options.forEach(o => {
       if (o.option.indexOf('<appCatalogUrl>') > -1) {
@@ -446,7 +446,7 @@ describe(commands.STORAGEENTITY_SET, () => {
   });
 
   it('requires tenant property name', () => {
-    const options = (storageEntitySetCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     let requiresTenantPropertyName = false;
     options.forEach(o => {
       if (o.option.indexOf('<key>') > -1) {
@@ -457,7 +457,7 @@ describe(commands.STORAGEENTITY_SET, () => {
   });
 
   it('requires tenant property value', () => {
-    const options = (storageEntitySetCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     let requiresTenantPropertyValue = false;
     options.forEach(o => {
       if (o.option.indexOf('<value>') > -1) {
@@ -468,7 +468,7 @@ describe(commands.STORAGEENTITY_SET, () => {
   });
 
   it('supports setting tenant property description', () => {
-    const options = (storageEntitySetCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     let supportsTenantPropertyDescription = false;
     options.forEach(o => {
       if (o.option.indexOf('[description]') > -1) {
@@ -479,7 +479,7 @@ describe(commands.STORAGEENTITY_SET, () => {
   });
 
   it('supports setting tenant property comment', () => {
-    const options = (storageEntitySetCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     let supportsTenantPropertyComment = false;
     options.forEach(o => {
       if (o.option.indexOf('[comment]') > -1) {
@@ -491,51 +491,56 @@ describe(commands.STORAGEENTITY_SET, () => {
 
   it('doesn\'t fail if the parent doesn\'t define options', () => {
     sinon.stub(Command.prototype, 'options').callsFake(() => { return undefined; });
-    const options = (storageEntitySetCommand.options() as CommandOption[]);
+    const options = (command.options() as CommandOption[]);
     Utils.restore(Command.prototype.options);
     assert(options.length > 0);
   });
 
   it('accepts valid SharePoint Online app catalog URL', () => {
-    const actual = (storageEntitySetCommand.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } });
+    const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } });
     assert(actual);
   });
 
   it('accepts valid SharePoint Online site URL', () => {
-    const actual = (storageEntitySetCommand.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com' } });
+    const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com' } });
     assert(actual);
   });
 
   it('rejects invalid SharePoint Online URL', () => {
     const url = 'https://contoso.com';
-    const actual = (storageEntitySetCommand.validate() as CommandValidate)({ options: { appCatalogUrl: url } });
+    const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: url } });
     assert.equal(actual, `${url} is not a valid SharePoint Online site URL`);
   });
 
   it('fails validation when no SharePoint Online app catalog URL specified', () => {
-    const actual = (storageEntitySetCommand.validate() as CommandValidate)({ options: {} });
+    const actual = (command.validate() as CommandValidate)({ options: {} });
     assert.equal(actual, 'Missing required option appCatalogUrl');
   });
 
   it('has help referring to the right command', () => {
-    const _helpLog: string[] = [];
-    const helpLog = (msg: string) => { _helpLog.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {},
+      prompt: () => {},
+      helpInformation: () => {}
     };
     const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (storageEntitySetCommand.help() as CommandHelp)({}, helpLog);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     assert(find.calledWith(commands.STORAGEENTITY_SET));
   });
 
   it('has help with examples', () => {
     const _log: string[] = [];
-    const log = (msg: string) => { _log.push(msg); }
     const cmd: any = {
-      helpInformation: () => { }
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => {},
+      helpInformation: () => {}
     };
     sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    (storageEntitySetCommand.help() as CommandHelp)({}, log);
+    cmd.help = command.help();
+    cmd.help({}, () => {});
     let containsExamples: boolean = false;
     _log.forEach(l => {
       if (l && l.indexOf('Examples:') > -1) {
@@ -552,7 +557,7 @@ describe(commands.STORAGEENTITY_SET, () => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
-    cmdInstance.action = storageEntitySetCommand.action();
+    cmdInstance.action = command.action();
     cmdInstance.action({ options: { debug: true, confirm: true, key: 'existingproperty', appCatalogUrl: 'https://contoso-admin.sharepoint.com' } }, () => {
       let containsError = false;
       log.forEach(l => {

--- a/src/o365/spo/commands/storageentity/storageentity-set.ts
+++ b/src/o365/spo/commands/storageentity/storageentity-set.ts
@@ -5,7 +5,6 @@ import * as request from 'request-promise-native';
 import commands from '../../commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import {
-  CommandHelp,
   CommandOption,
   CommandValidate,
   CommandError
@@ -149,12 +148,11 @@ class SpoStorageEntitySetCommand extends SpoCommand {
     };
   }
 
-  public help(): CommandHelp {
-    return function (args: CommandArgs, log: (help: string) => void): void {
-      const chalk = vorpal.chalk;
-      log(vorpal.find(commands.STORAGEENTITY_SET).helpInformation());
-      log(
-        `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
+  public commandHelp(args: CommandArgs, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(commands.STORAGEENTITY_SET).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online tenant admin site,
   using the ${chalk.blue(commands.CONNECT)} command.
                 
   Remarks:
@@ -180,7 +178,6 @@ class SpoStorageEntitySetCommand extends SpoCommand {
     SharePoint Framework Tenant Properties
       https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties
 `);
-    };
   }
 }
 

--- a/types/vorpal.d.ts
+++ b/types/vorpal.d.ts
@@ -15,7 +15,7 @@ interface Vorpal {
 interface VorpalCommand {
   action: (action: (this: CommandInstance, args: any, callback: () => void) => void) => VorpalCommand;
   cancel: (handler: () => void) => VorpalCommand;
-  help: (help: (args: any, log: (help: string) => void) => void) => VorpalCommand;
+  help: (help: (args: any, cbOrLog: (message?: string) => void) => void) => VorpalCommand;
   helpInformation: () => string;
   option: (name: string, description?: string, autocomplete?: string[]) => VorpalCommand;
   types: (types: { string?: string[], boolean?: string[] }) => VorpalCommand;


### PR DESCRIPTION
Fixed issue with rendering help using --help solving #104 

It turns out that vorpal has an odd implementation of the custom help methods. Depending whether you call help using `help <command>` or `<command> --help` the second argument in the command's `help` method is either the `log` method or the `callback` you have to call to prevent the CLI from crashing. To fix the issue I changed the implementation of help in the `Command` base class and abstracted away all vorpal intricacies. Instead dealing with them, when building commands, all you have to do is to implement new abstract method named `commandHelp` and you will be all set.