### PR TITLE
Auth.getAccessToken updates Service.accessToken property

### DIFF
--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -243,6 +243,7 @@ export default class Auth {
             stdout.log('');
           }
 
+          this.service.accessToken = json.access_token;
           resolve(json.access_token);
         }, (err: any): void => {
           reject(err);

--- a/src/o365/spo/SpoAuth.ts
+++ b/src/o365/spo/SpoAuth.ts
@@ -90,7 +90,10 @@ class SpoAuth extends Auth {
       const now: number = new Date().getTime() / 1000;
       const token: Token | undefined = this.site.accessTokens[resource];
       if (token && token.expiresAt > now) {
-        resolve(this.site.accessTokens[resource].accessToken);
+
+        const token = this.site.accessTokens[resource].accessToken
+        this.site.accessToken = token;
+        resolve(token);
         return;
       }
 
@@ -104,11 +107,13 @@ class SpoAuth extends Auth {
           this
             .setServiceConnectionInfo(this.SERVICE, this.site)
             .then((): void => {
+              this.site.accessToken = accessToken;
               resolve(accessToken);
             }, (error: any): void => {
               if (debug) {
                 stdout.log(new CommandError(error));
               }
+              this.site.accessToken = accessToken;
               resolve(accessToken);
             });
         }, (error: any): void => {


### PR DESCRIPTION
Quick solution for #118.

Auth.getAccessToken method updates Service.accessToken property when new token is retrieved to ensure that the property does not hold old token used under different context (tenant admin or site collection only context)

We have to unit test that property in future somehow. I did not have enough time now to back it with unit tests so feel free to reject that quick fix.