### PR TITLE
Added detecting dev version of the CLI to the telemetry

### DIFF
--- a/src/appInsights.spec.ts
+++ b/src/appInsights.spec.ts
@@ -1,0 +1,23 @@
+import * as sinon from 'sinon';
+import * as assert from 'assert';
+import Utils from './Utils';
+import * as fs from 'fs';
+
+describe('appInsights', () => {
+  afterEach(() => {
+    Utils.restore(fs.existsSync);
+    delete require.cache[require.resolve('./appInsights')];
+  });
+
+  it('adds -dev label to version logged in the telemetry when CLI ran locally', () => {
+    sinon.stub(fs, 'existsSync').callsFake(() => true);
+    const i: any = require('./appInsights');
+    assert(i.default.commonProperties.version.indexOf('-dev') > -1);
+  });
+
+  it('doesn\'t add -dev label to version logged in the telemetry when CLI installed from npm', () => {
+    sinon.stub(fs, 'existsSync').callsFake(() => false);
+    const i: any = require('./appInsights');
+    assert(i.default.commonProperties.version.indexOf('-dev') === -1);
+  });
+})

--- a/src/appInsights.ts
+++ b/src/appInsights.ts
@@ -1,11 +1,17 @@
 const packageJSON = require('../package.json');
+import * as fs from 'fs';
+import * as path from 'path';
 
 import * as appInsights from 'applicationinsights';
 const config = appInsights.setup('6b908c80-d09f-4cf6-8274-e54349a0149a');
 config.setInternalLogging(false, false);
 appInsights.start();
+// append -dev to the version number when ran locally
+// to distinguish production and dev version of the CLI
+// in the telemetry
+const version: string = `${packageJSON.version}${fs.existsSync(path.join(__dirname, `..${path.sep}src`)) ? '-dev' : ''}`;
 appInsights.defaultClient.commonProperties = {
-  version: packageJSON.version
+  version: version
 };
 
 export default appInsights.defaultClient;


### PR DESCRIPTION
Currently, in the telemetry we make no distinction between the production and dev version of the CLI which gives us skewed metrics. This PR contains a fix that adds the flag `-dev` to the version logged in the telemetry when the CLI is ran locally.