### PR TITLE
assert(actual) changed to assert.equal(actual, true) fixing #194

### DIFF
--- a/src/Utils.spec.ts
+++ b/src/Utils.spec.ts
@@ -9,7 +9,7 @@ import * as os from 'os';
 describe('Utils', () => {
   it('isValidGuid returns true if valid guid', () => {
     const result = Utils.isValidGuid('b2307a39-e878-458b-bc90-03bc578531d6');
-    assert(result);
+    assert.equal(result, true);
   });
 
   it('isValidGuid returns false if invalid guid', () => {

--- a/src/auth/FileTokenStorage.spec.ts
+++ b/src/auth/FileTokenStorage.spec.ts
@@ -339,7 +339,7 @@ describe('FileTokenStorage', () => {
       .remove('mock')
       .then(() => {
         try {
-          assert(actual, JSON.stringify(expected));
+          assert.equal(actual, JSON.stringify(expected));
           done();
         }
         catch (e) {
@@ -366,7 +366,7 @@ describe('FileTokenStorage', () => {
       .remove('mock')
       .then(() => {
         try {
-          assert(actual, JSON.stringify(expected));
+          assert.equal(actual, JSON.stringify(expected));
           done();
         }
         catch (e) {

--- a/src/o365/aad/commands/oauth2grant/oauth2grant-add.spec.ts
+++ b/src/o365/aad/commands/oauth2grant/oauth2grant-add.spec.ts
@@ -219,7 +219,7 @@ describe(commands.OAUTH2GRANT_ADD, () => {
 
   it('passes validation when clientId, resourceId and scope are specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { clientId: '6a7b1395-d313-4682-8ed4-65a6265a6320', resourceId: '6a7b1395-d313-4682-8ed4-65a6265a6320', scope: 'user_impersonation' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('supports debug mode', () => {

--- a/src/o365/aad/commands/oauth2grant/oauth2grant-list.spec.ts
+++ b/src/o365/aad/commands/oauth2grant/oauth2grant-list.spec.ts
@@ -292,7 +292,7 @@ describe(commands.OAUTH2GRANT_LIST, () => {
 
   it('passes validation when the clientId option specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { clientId: '6a7b1395-d313-4682-8ed4-65a6265a6320' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('supports debug mode', () => {

--- a/src/o365/aad/commands/oauth2grant/oauth2grant-remove.spec.ts
+++ b/src/o365/aad/commands/oauth2grant/oauth2grant-remove.spec.ts
@@ -189,7 +189,7 @@ describe(commands.OAUTH2GRANT_REMOVE, () => {
 
   it('passes validation when grantId is specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { grantId: 'YgA60KYa4UOPSdc-lpxYEnQkr8KVLDpCsOXkiV8i-ek' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('supports debug mode', () => {

--- a/src/o365/aad/commands/oauth2grant/oauth2grant-set.spec.ts
+++ b/src/o365/aad/commands/oauth2grant/oauth2grant-set.spec.ts
@@ -200,7 +200,7 @@ describe(commands.OAUTH2GRANT_SET, () => {
 
   it('passes validation when grantId and scope are specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { grantId: 'YgA60KYa4UOPSdc-lpxYEnQkr8KVLDpCsOXkiV8i-ek', scope: 'user_impersonation' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('supports debug mode', () => {

--- a/src/o365/aad/commands/sp/sp-get.spec.ts
+++ b/src/o365/aad/commands/sp/sp-get.spec.ts
@@ -260,12 +260,12 @@ describe(commands.SP_GET, () => {
 
   it('passes validation when the appId option specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { appId: '6a7b1395-d313-4682-8ed4-65a6265a6320' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('passes validation when the displayName option specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { displayName: 'Microsoft Graph' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('fails validation when both the appId and displayName are specified', () => {

--- a/src/o365/spo/commands/app/app-add.spec.ts
+++ b/src/o365/spo/commands/app/app-add.spec.ts
@@ -413,7 +413,7 @@ describe(commands.APP_ADD, () => {
       fs.existsSync,
       fs.lstatSync
     ]);
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('has help referring to the right command', () => {

--- a/src/o365/spo/commands/app/app-deploy.spec.ts
+++ b/src/o365/spo/commands/app/app-deploy.spec.ts
@@ -970,12 +970,12 @@ describe(commands.APP_DEPLOY, () => {
 
   it('passes validation when the id is specified and the appCatalogUrl is not', () => {
     const actual = (command.validate() as CommandValidate)({ options: { id: '123' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('passes validation when the id and appCatalogUrl options are specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { id: '123', appCatalogUrl: 'https://contoso.sharepoint.com' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('supports debug mode', () => {

--- a/src/o365/spo/commands/app/app-get.spec.ts
+++ b/src/o365/spo/commands/app/app-get.spec.ts
@@ -306,7 +306,7 @@ describe(commands.APP_GET, () => {
 
   it('passes validation when the id option specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { id: '123' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('supports debug mode', () => {

--- a/src/o365/spo/commands/app/app-install.spec.ts
+++ b/src/o365/spo/commands/app/app-install.spec.ts
@@ -468,7 +468,7 @@ describe(commands.APP_INSTALL, () => {
 
   it('passes validation when the id and siteUrl options are specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { id: '123', siteUrl: 'https://contoso.sharepoint.com' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('supports debug mode', () => {

--- a/src/o365/spo/commands/app/app-remove.spec.ts
+++ b/src/o365/spo/commands/app/app-remove.spec.ts
@@ -849,12 +849,12 @@ describe(commands.APP_REMOVE, () => {
 
   it('passes validation when the id is specified and the appCatalogUrl is not', () => {
     const actual = (command.validate() as CommandValidate)({ options: { id: 'dd20afdf-d7fd-4662-a443-b69e65a72bd4' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('passes validation when the id and appCatalogUrl options are specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { id: 'dd20afdf-d7fd-4662-a443-b69e65a72bd4', appCatalogUrl: 'https://contoso.sharepoint.com' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('supports debug mode', () => {

--- a/src/o365/spo/commands/app/app-retract.spec.ts
+++ b/src/o365/spo/commands/app/app-retract.spec.ts
@@ -897,12 +897,12 @@ describe(commands.APP_RETRACT, () => {
 
   it('passes validation when the id is specified and the appCatalogUrl is not', () => {
     const actual = (command.validate() as CommandValidate)({ options: { id: '123' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('passes validation when the id and appCatalogUrl options are specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { id: '123', appCatalogUrl: 'https://contoso.sharepoint.com' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('supports debug mode', () => {

--- a/src/o365/spo/commands/app/app-uninstall.spec.ts
+++ b/src/o365/spo/commands/app/app-uninstall.spec.ts
@@ -576,7 +576,7 @@ describe(commands.APP_UNINSTALL, () => {
 
   it('passes validation when the id and siteUrl options are specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { id: '123', siteUrl: 'https://contoso.sharepoint.com' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('supports debug mode', () => {

--- a/src/o365/spo/commands/app/app-upgrade.spec.ts
+++ b/src/o365/spo/commands/app/app-upgrade.spec.ts
@@ -419,7 +419,7 @@ describe(commands.APP_UPGRADE, () => {
 
   it('passes validation when the id and siteUrl options are specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { id: '123', siteUrl: 'https://contoso.sharepoint.com' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('supports debug mode', () => {

--- a/src/o365/spo/commands/cdn/cdn-get.spec.ts
+++ b/src/o365/spo/commands/cdn/cdn-get.spec.ts
@@ -412,12 +412,12 @@ describe(commands.CDN_GET, () => {
 
   it('accepts Public SharePoint Online CDN type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'Public' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts Private SharePoint Online CDN type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'Private' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid SharePoint Online CDN type', () => {
@@ -428,7 +428,7 @@ describe(commands.CDN_GET, () => {
 
   it('doesn\'t fail validation if the optional type option not specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: {} });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('has help referring to the right command', () => {

--- a/src/o365/spo/commands/cdn/cdn-origin-add.spec.ts
+++ b/src/o365/spo/commands/cdn/cdn-origin-add.spec.ts
@@ -378,12 +378,12 @@ describe(commands.CDN_ORIGIN_ADD, () => {
 
   it('accepts Public SharePoint Online CDN type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'Public' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts Private SharePoint Online CDN type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'Private' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid SharePoint Online CDN type', () => {
@@ -394,7 +394,7 @@ describe(commands.CDN_ORIGIN_ADD, () => {
 
   it('doesn\'t fail validation if the optional type option not specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: {} });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('has help referring to the right command', () => {

--- a/src/o365/spo/commands/cdn/cdn-origin-list.spec.ts
+++ b/src/o365/spo/commands/cdn/cdn-origin-list.spec.ts
@@ -379,12 +379,12 @@ describe(commands.CDN_ORIGIN_LIST, () => {
 
   it('accepts Public SharePoint Online CDN type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'Public' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts Private SharePoint Online CDN type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'Private' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid SharePoint Online CDN type', () => {
@@ -395,7 +395,7 @@ describe(commands.CDN_ORIGIN_LIST, () => {
 
   it('doesn\'t fail validation if the optional type option not specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: {} });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('has help referring to the right command', () => {

--- a/src/o365/spo/commands/cdn/cdn-origin-remove.spec.ts
+++ b/src/o365/spo/commands/cdn/cdn-origin-remove.spec.ts
@@ -434,12 +434,12 @@ describe(commands.CDN_ORIGIN_REMOVE, () => {
 
   it('accepts Public SharePoint Online CDN type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'Public' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts Private SharePoint Online CDN type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'Private' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid SharePoint Online CDN type', () => {
@@ -450,7 +450,7 @@ describe(commands.CDN_ORIGIN_REMOVE, () => {
 
   it('doesn\'t fail validation if the optional type option not specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: {} });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('has help referring to the right command', () => {

--- a/src/o365/spo/commands/cdn/cdn-policy-list.spec.ts
+++ b/src/o365/spo/commands/cdn/cdn-policy-list.spec.ts
@@ -344,12 +344,12 @@ describe(commands.CDN_POLICY_LIST, () => {
 
   it('accepts Public SharePoint Online CDN type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'Public' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts Private SharePoint Online CDN type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'Private' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid SharePoint Online CDN type', () => {
@@ -360,7 +360,7 @@ describe(commands.CDN_POLICY_LIST, () => {
 
   it('doesn\'t fail validation if the optional type option not specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: {} });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('has help referring to the right command', () => {

--- a/src/o365/spo/commands/cdn/cdn-policy-set.spec.ts
+++ b/src/o365/spo/commands/cdn/cdn-policy-set.spec.ts
@@ -392,12 +392,12 @@ describe(commands.CDN_POLICY_SET, () => {
 
   it('accepts Public SharePoint Online CDN type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'Public', policy: 'IncludeFileExtensions' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts Private SharePoint Online CDN type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'Private', policy: 'IncludeFileExtensions' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid SharePoint Online CDN type', () => {
@@ -408,17 +408,17 @@ describe(commands.CDN_POLICY_SET, () => {
 
   it('doesn\'t fail validation if the optional type option not specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { policy: 'IncludeFileExtensions' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts IncludeFileExtensions SharePoint Online CDN policy', () => {
     const actual = (command.validate() as CommandValidate)({ options: { policy: 'IncludeFileExtensions' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts ExcludeRestrictedSiteClassifications SharePoint Online CDN policy', () => {
     const actual = (command.validate() as CommandValidate)({ options: { policy: 'ExcludeRestrictedSiteClassifications' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid SharePoint Online CDN policy', () => {

--- a/src/o365/spo/commands/cdn/cdn-set.spec.ts
+++ b/src/o365/spo/commands/cdn/cdn-set.spec.ts
@@ -337,12 +337,12 @@ describe(commands.CDN_SET, () => {
 
   it('accepts Public SharePoint Online CDN type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'Public', enabled: 'true' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts Private SharePoint Online CDN type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'Private', enabled: 'true' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid SharePoint Online CDN type', () => {
@@ -353,37 +353,37 @@ describe(commands.CDN_SET, () => {
 
   it('doesn\'t fail validation if the optional type option not specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { enabled: 'true' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts true SharePoint Online CDN enabled state', () => {
     const actual = (command.validate() as CommandValidate)({ options: { enabled: 'true' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts True SharePoint Online CDN enabled state', () => {
     const actual = (command.validate() as CommandValidate)({ options: { enabled: 'True' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts TRUE SharePoint Online CDN enabled state', () => {
     const actual = (command.validate() as CommandValidate)({ options: { enabled: 'TRUE' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts false SharePoint Online CDN enabled state', () => {
     const actual = (command.validate() as CommandValidate)({ options: { enabled: 'false' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts False SharePoint Online CDN enabled state', () => {
     const actual = (command.validate() as CommandValidate)({ options: { enabled: 'False' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts FALSE SharePoint Online CDN enabled state', () => {
     const actual = (command.validate() as CommandValidate)({ options: { enabled: 'FALSE' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid SharePoint Online CDN enabled state', () => {

--- a/src/o365/spo/commands/connect.spec.ts
+++ b/src/o365/spo/commands/connect.spec.ts
@@ -174,7 +174,7 @@ describe(commands.CONNECT, () => {
 
   it('accepts valid SharePoint Online URL', () => {
     const actual = (command.validate() as CommandValidate)({ url: 'https://contoso.sharepoint.com' });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid SharePoint Online URL', () => {

--- a/src/o365/spo/commands/customaction/customaction-get.spec.ts
+++ b/src/o365/spo/commands/customaction/customaction-get.spec.ts
@@ -698,7 +698,7 @@ describe(commands.CUSTOMACTION_GET, () => {
           url: "https://contoso.sharepoint.com"
         }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('passes validation when the id, url and scope options specified', () => {
@@ -710,7 +710,7 @@ describe(commands.CUSTOMACTION_GET, () => {
           scope: "Site"
         }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('passes validation when the id and url option specified', () => {
@@ -721,7 +721,7 @@ describe(commands.CUSTOMACTION_GET, () => {
           url: "https://contoso.sharepoint.com"
         }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('humanize scope shows correct value when scope odata is 2', () => {
@@ -748,7 +748,7 @@ describe(commands.CUSTOMACTION_GET, () => {
           scope: 'All'
         }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts scope to be Site', () => {
@@ -760,7 +760,7 @@ describe(commands.CUSTOMACTION_GET, () => {
           scope: 'Site'
         }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts scope to be Web', () => {
@@ -772,7 +772,7 @@ describe(commands.CUSTOMACTION_GET, () => {
           scope: 'Web'
         }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid string scope', () => {
@@ -808,7 +808,7 @@ describe(commands.CUSTOMACTION_GET, () => {
             url: "https://contoso.sharepoint.com"
           }
       });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('has help referring to the right command', () => {

--- a/src/o365/spo/commands/customaction/customaction-list.spec.ts
+++ b/src/o365/spo/commands/customaction/customaction-list.spec.ts
@@ -592,7 +592,7 @@ describe(commands.CUSTOMACTION_LIST, () => {
           url: "https://contoso.sharepoint.com"
         }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('passes validation when the url and scope options specified', () => {
@@ -603,7 +603,7 @@ describe(commands.CUSTOMACTION_LIST, () => {
           scope: "Site"
         }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('humanize scope shows correct value when scope odata is 2', () => {
@@ -629,7 +629,7 @@ describe(commands.CUSTOMACTION_LIST, () => {
           scope: 'All'
         }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts scope to be Site', () => {
@@ -640,7 +640,7 @@ describe(commands.CUSTOMACTION_LIST, () => {
           scope: 'Site'
         }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts scope to be Web', () => {
@@ -651,7 +651,7 @@ describe(commands.CUSTOMACTION_LIST, () => {
           scope: 'Web'
         }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid string scope', () => {
@@ -684,7 +684,7 @@ describe(commands.CUSTOMACTION_LIST, () => {
             url: "https://contoso.sharepoint.com"
           }
       });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('has help referring to the right command', () => {

--- a/src/o365/spo/commands/serviceprincipal/serviceprincipal-grant-revoke.spec.ts
+++ b/src/o365/spo/commands/serviceprincipal/serviceprincipal-grant-revoke.spec.ts
@@ -261,7 +261,7 @@ describe(commands.SERVICEPRINCIPAL_GRANT_REVOKE, () => {
 
   it('passes validation when the grantId is specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { grantId: '50NAzUm3C0K9B6p8ORLtIvNe8tzf4ndKg51reFehHHg' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('has help referring to the right command', () => {

--- a/src/o365/spo/commands/serviceprincipal/serviceprincipal-permissionrequest-approve.spec.ts
+++ b/src/o365/spo/commands/serviceprincipal/serviceprincipal-permissionrequest-approve.spec.ts
@@ -280,7 +280,7 @@ describe(commands.SERVICEPRINCIPAL_PERMISSIONREQUEST_APPROVE, () => {
 
   it('passes validation when the requestId is a valid GUID', () => {
     const actual = (command.validate() as CommandValidate)({ options: { requestId: '4dc4c043-25ee-40f2-81d3-b3bf63da7538' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('has help referring to the right command', () => {

--- a/src/o365/spo/commands/serviceprincipal/serviceprincipal-permissionrequest-deny.spec.ts
+++ b/src/o365/spo/commands/serviceprincipal/serviceprincipal-permissionrequest-deny.spec.ts
@@ -253,7 +253,7 @@ describe(commands.SERVICEPRINCIPAL_PERMISSIONREQUEST_DENY, () => {
 
   it('passes validation when the requestId is a valid GUID', () => {
     const actual = (command.validate() as CommandValidate)({ options: { requestId: '4dc4c043-25ee-40f2-81d3-b3bf63da7538' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('defines alias', () => {

--- a/src/o365/spo/commands/serviceprincipal/serviceprincipal-set.spec.ts
+++ b/src/o365/spo/commands/serviceprincipal/serviceprincipal-set.spec.ts
@@ -420,12 +420,12 @@ describe(commands.SERVICEPRINCIPAL_SET, () => {
 
   it('passes validation when the enabled option is true', () => {
     const actual = (command.validate() as CommandValidate)({ options: { enabled: 'true' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('passes validation when the enabled option is false', () => {
     const actual = (command.validate() as CommandValidate)({ options: { enabled: 'false' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('has help referring to the right command', () => {

--- a/src/o365/spo/commands/site/site-add.spec.ts
+++ b/src/o365/spo/commands/site/site-add.spec.ts
@@ -914,7 +914,7 @@ describe(commands.SITE_ADD, () => {
         alias: 'team1'
       }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('passes validation when the TeamSite type option specified', () => {
@@ -925,7 +925,7 @@ describe(commands.SITE_ADD, () => {
         alias: 'team1'
       }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('passes validation when the CommunicationSite type option specified', () => {
@@ -936,7 +936,7 @@ describe(commands.SITE_ADD, () => {
         url: 'https://contoso.sharepoint.com/sites/marketing'
       }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('fails validation if an invalid type option specified', () => {
@@ -997,7 +997,7 @@ describe(commands.SITE_ADD, () => {
         url: 'https://contoso.sharepoint.com/sites/marketing'
       }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('passes validation when the type is CommunicationSite and siteDesign is Topic', () => {
@@ -1009,7 +1009,7 @@ describe(commands.SITE_ADD, () => {
         siteDesign: 'Topic'
       }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('passes validation when the type is CommunicationSite and siteDesign is Showcase', () => {
@@ -1021,7 +1021,7 @@ describe(commands.SITE_ADD, () => {
         siteDesign: 'Showcase'
       }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('passes validation when the type is CommunicationSite and siteDesign is Blank', () => {
@@ -1033,7 +1033,7 @@ describe(commands.SITE_ADD, () => {
         siteDesign: 'Blank'
       }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('fails validation when the type is CommunicationSite and siteDesign is invalid', () => {
@@ -1057,7 +1057,7 @@ describe(commands.SITE_ADD, () => {
         siteDesignId: '92398ab7-45c7-486b-81fa-54da2ee0738a'
       }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('fails validation when the type is CommunicationSite and siteDesignId is not a valid GUID', () => {
@@ -1069,7 +1069,7 @@ describe(commands.SITE_ADD, () => {
         siteDesignId: 'abc'
       }
     });
-    assert(actual);
+    assert.notEqual(actual, true);
   });
 
   it('fails validation when the type is CommunicationSite and both siteDesign and siteDesignId are specified', () => {
@@ -1082,7 +1082,7 @@ describe(commands.SITE_ADD, () => {
         siteDesignId: '92398ab7-45c7-486b-81fa-54da2ee0738a'
       }
     });
-    assert(actual);
+    assert.notEqual(actual, true);
   });
 
   it('has help referring to the right command', () => {

--- a/src/o365/spo/commands/site/site-appcatalog-add.spec.ts
+++ b/src/o365/spo/commands/site/site-appcatalog-add.spec.ts
@@ -264,7 +264,7 @@ describe(commands.SITE_APPCATALOG_ADD, () => {
         url: 'https://contoso.sharepoint.com/sites/site'
       }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('fails validation when the url option not specified', () => {

--- a/src/o365/spo/commands/site/site-appcatalog-remove.spec.ts
+++ b/src/o365/spo/commands/site/site-appcatalog-remove.spec.ts
@@ -260,7 +260,7 @@ describe(commands.SITE_APPCATALOG_REMOVE, () => {
         url: 'https://contoso.sharepoint.com/sites/site'
       }
     });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('fails validation when the url option not specified', () => {

--- a/src/o365/spo/commands/site/site-get.spec.ts
+++ b/src/o365/spo/commands/site/site-get.spec.ts
@@ -284,7 +284,7 @@ describe(commands.SITE_GET, () => {
 
   it('passes validation if the url option is a valid SharePoint site URL', () => {
     const actual = (command.validate() as CommandValidate)({ options: { url: 'https://contoso.sharepoint.com' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('has help referring to the right command', () => {

--- a/src/o365/spo/commands/site/site-list.spec.ts
+++ b/src/o365/spo/commands/site/site-list.spec.ts
@@ -672,12 +672,12 @@ describe(commands.SITE_LIST, () => {
 
   it('accepts TeamSite site type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'TeamSite' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts CommunicationSite site type', () => {
     const actual = (command.validate() as CommandValidate)({ options: { type: 'CommunicationSite' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid site type', () => {
@@ -688,7 +688,7 @@ describe(commands.SITE_LIST, () => {
 
   it('doesn\'t fail validation if the optional type option not specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: {} });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('has help referring to the right command', () => {

--- a/src/o365/spo/commands/storageentity/storageentity-list.spec.ts
+++ b/src/o365/spo/commands/storageentity/storageentity-list.spec.ts
@@ -350,12 +350,12 @@ describe(commands.STORAGEENTITY_LIST, () => {
 
   it('accepts valid SharePoint Online app catalog URL', () => {
     const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }});
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts valid SharePoint Online site URL', () => {
     const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com' }});
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid SharePoint Online URL', () => {

--- a/src/o365/spo/commands/storageentity/storageentity-remove.spec.ts
+++ b/src/o365/spo/commands/storageentity/storageentity-remove.spec.ts
@@ -359,12 +359,12 @@ describe(commands.STORAGEENTITY_REMOVE, () => {
 
   it('accepts valid SharePoint Online app catalog URL', () => {
     const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' }});
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts valid SharePoint Online site URL', () => {
     const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com' }});
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid SharePoint Online URL', () => {

--- a/src/o365/spo/commands/storageentity/storageentity-set.spec.ts
+++ b/src/o365/spo/commands/storageentity/storageentity-set.spec.ts
@@ -498,12 +498,12 @@ describe(commands.STORAGEENTITY_SET, () => {
 
   it('accepts valid SharePoint Online app catalog URL', () => {
     const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com/sites/appcatalog' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('accepts valid SharePoint Online site URL', () => {
     const actual = (command.validate() as CommandValidate)({ options: { appCatalogUrl: 'https://contoso.sharepoint.com' } });
-    assert(actual);
+    assert.equal(actual, true);
   });
 
   it('rejects invalid SharePoint Online URL', () => {


### PR DESCRIPTION
Replaced 87 occurrences of 'assert(actual)' across 35 files with 'assert.equal(actual, true)'.

Two tests fixed:
	spo site add -> fails validation when the type is CommunicationSite and siteDesignId is not a valid GUID
	spo site add -> fails validation when the type is CommunicationSite and both siteDesign and siteDesignId are specified

Three non command validation tests also fixed:
	FileTokenStorage -> removes password for the specified service from the token file,
	FileTokenStorage -> removes password for the specified service from the token file keeping other passwords intact
	Utils -> isValidGuid returns true if valid guid

Solves issue #194 