### PR TITLE
Changed listing output to optional option in the docs

### DIFF
--- a/docs/manual/docs/cmd/aad/connect.md
+++ b/docs/manual/docs/cmd/aad/connect.md
@@ -13,7 +13,7 @@ aad connect [options]
 Option|Description
 ------|-----------
 `--help`|output usage information
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/aad/disconnect.md
+++ b/docs/manual/docs/cmd/aad/disconnect.md
@@ -13,7 +13,7 @@ aad disconnect [options]
 Option|Description
 ------|-----------
 `--help`|output usage information
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/aad/oauth2grant/oauth2grant-add.md
+++ b/docs/manual/docs/cmd/aad/oauth2grant/oauth2grant-add.md
@@ -16,7 +16,7 @@ Option|Description
 `-i, --clientId <clientId>`|`objectId` of the service principal for which permissions should be granted
 `-r, --resourceId <resourceId>`|`objectId` of the AAD application to which permissions should be granted
 `-s, --scope <scope>`|Permissions to grant
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/aad/oauth2grant/oauth2grant-list.md
+++ b/docs/manual/docs/cmd/aad/oauth2grant/oauth2grant-list.md
@@ -14,7 +14,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-i, --clientId <clientId>`|objectId of the service principal for which the configured OAuth2 permission grants should be retrieved
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/aad/oauth2grant/oauth2grant-remove.md
+++ b/docs/manual/docs/cmd/aad/oauth2grant/oauth2grant-remove.md
@@ -14,7 +14,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-i, --grantId <grantId>`|`objectId` of OAuth2 permission grant to remove
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/aad/oauth2grant/oauth2grant-set.md
+++ b/docs/manual/docs/cmd/aad/oauth2grant/oauth2grant-set.md
@@ -15,7 +15,7 @@ Option|Description
 `--help`|output usage information
 `-i, --grantId <grantId>`|`objectId` of OAuth2 permission grant to update
 `-s, --scope <scope>`|Permissions to grant
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/aad/sp/sp-get.md
+++ b/docs/manual/docs/cmd/aad/sp/sp-get.md
@@ -15,7 +15,7 @@ Option|Description
 `--help`|output usage information
 `-i, --appId [appId]`|ID of the application for which the service principal should be retrieved
 `-n, --displayName [displayName]`|Display name of the application for which the service principal should be retrieved
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/aad/status.md
+++ b/docs/manual/docs/cmd/aad/status.md
@@ -13,7 +13,7 @@ aad status [options]
 Option|Description
 ------|-----------
 `--help`|output usage information
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/app/app-add.md
+++ b/docs/manual/docs/cmd/spo/app/app-add.md
@@ -15,7 +15,7 @@ Option|Description
 `--help`|output usage information
 `-p, --filePath <filePath>`|Absolute or relative path to the solution package file to add to the app catalog
 `--overwrite`|Set to overwrite the existing package file
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -24,8 +24,7 @@ Option|Description
 
 ## Remarks
 
-To add an app to the tenant app catalog, you have to first connect to a SharePoint site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
+To add an app to the tenant app catalog, you have to first connect to a SharePoint site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
 
 When specifying the path to the app package file you can use both relative and absolute paths. Note, that `~` in the path, will not be resolved and will most likely result in an error.
 

--- a/docs/manual/docs/cmd/spo/app/app-deploy.md
+++ b/docs/manual/docs/cmd/spo/app/app-deploy.md
@@ -16,7 +16,7 @@ Option|Description
 `-i, --id <id>`|ID of the app to deploy. Needs to be available in the tenant app catalog.
 `-u, --appCatalogUrl [appCatalogUrl]`|(optional) URL of the tenant app catalog site. If not specified, the CLI will try to resolve it automatically
 `--skipFeatureDeployment`|If the app supports tenant-wide deployment, deploy it to the whole tenant
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -25,8 +25,7 @@ Option|Description
 
 ## Remarks
 
-To deploy an app in the tenant app catalog, you have to first connect to a SharePoint site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
+To deploy an app in the tenant app catalog, you have to first connect to a SharePoint site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
 
 If you don't specify the URL of the tenant app catalog site using the **appCatalogUrl** option, the CLI will try to determine its URL automatically. This will be done using SharePoint Search. If the tenant app catalog site hasn't been crawled yet, the CLI will not find it and will prompt you to provide the URL yourself.
 

--- a/docs/manual/docs/cmd/spo/app/app-get.md
+++ b/docs/manual/docs/cmd/spo/app/app-get.md
@@ -14,7 +14,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-i, --id <id>`|ID of the app to retrieve information for
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -23,8 +23,7 @@ Option|Description
 
 ## Remarks
 
-To get information about the specified app available in the tenant app catalog, you have to first connect to a SharePoint site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
+To get information about the specified app available in the tenant app catalog, you have to first connect to a SharePoint site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/app/app-install.md
+++ b/docs/manual/docs/cmd/spo/app/app-install.md
@@ -15,7 +15,7 @@ Option|Description
 `--help`|output usage information
 `-i, --id <id>`|ID of the app to retrieve information for
 `-s, --siteUrl <siteUrl>`|Absolute URL of the site to install the app in
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/app/app-list.md
+++ b/docs/manual/docs/cmd/spo/app/app-list.md
@@ -13,7 +13,7 @@ spo app list [options]
 Option|Description
 ------|-----------
 `--help`|output usage information
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -22,8 +22,7 @@ Option|Description
 
 ## Remarks
 
-To list the apps available in the tenant app catalog, you have to first connect to a SharePoint site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
+To list the apps available in the tenant app catalog, you have to first connect to a SharePoint site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/app/app-remove.md
+++ b/docs/manual/docs/cmd/spo/app/app-remove.md
@@ -16,7 +16,7 @@ Option|Description
 `-i, --id <id>`|ID of the app to remove. Needs to be available in the tenant app catalog.
 `-u, --appCatalogUrl [appCatalogUrl]`|(optional) URL of the tenant app catalog site. If not specified, the CLI will try to resolve it automatically
 `--confirm`|Don't prompt for confirming removing the app from the tenant app catalog
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/app/app-retract.md
+++ b/docs/manual/docs/cmd/spo/app/app-retract.md
@@ -16,7 +16,7 @@ Option|Description
 `-i, --id <id>`|ID of the app to retract. Needs to be available in the tenant app catalog.
 `-u, --appCatalogUrl [appCatalogUrl]`|(optional) URL of the tenant app catalog site. If not specified, the CLI will try to resolve it automatically
 `--confirm`|Don't prompt for confirming retracting the app from the tenant app catalog
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/app/app-uninstall.md
+++ b/docs/manual/docs/cmd/spo/app/app-uninstall.md
@@ -16,7 +16,7 @@ Option|Description
 `-i, --id <id>`|ID of the app to retrieve information for
 `-s, --siteUrl <siteUrl>`|Absolute URL of the site to uninstall the app from
 `--confirm`|Don't prompt for confirming uninstalling the app
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/app/app-upgrade.md
+++ b/docs/manual/docs/cmd/spo/app/app-upgrade.md
@@ -15,7 +15,7 @@ Option|Description
 `--help`|output usage information
 `-i, --id <id>`|ID of the app to retrieve information for
 `-s, --siteUrl <siteUrl>`|Absolute URL of the site to install the app in
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/cdn/cdn-get.md
+++ b/docs/manual/docs/cmd/spo/cdn/cdn-get.md
@@ -14,7 +14,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-t, --type [type]`|Type of CDN to manage. `Public|Private`. Default `Public`
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -23,13 +23,9 @@ Option|Description
 
 ## Remarks
 
-To view the status of an Office 365 CDN, you have to first connect to a tenant admin site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`.
-If you are connected to a different site and will try to manage tenant properties,
-you will get an error.
+To view the status of an Office 365 CDN, you have to first connect to a tenant admin site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`. If you are connected to a different site and will try to manage tenant properties, you will get an error.
 
-Using the `-t, --type` option you can choose whether you want to manage the settings of
-the Public (default) or Private CDN. If you don't use the option, the command will use the Public CDN.
+Using the `-t, --type` option you can choose whether you want to manage the settings of the Public (default) or Private CDN. If you don't use the option, the command will use the Public CDN.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/cdn/cdn-origin-add.md
+++ b/docs/manual/docs/cmd/spo/cdn/cdn-origin-add.md
@@ -15,7 +15,7 @@ Option|Description
 `--help`|output usage information
 `-t, --type [type]`|Type of CDN to manage. `Public|Private`. Default `Public`
 `-r, --origin <origin>`|Origin to add to the current CDN configuration
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -24,13 +24,9 @@ Option|Description
 
 ## Remarks
 
-To add origins to an Office 365 CDN, you have to first connect to a tenant admin site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`.
-If you are connected to a different site and will try to manage tenant properties,
-you will get an error.
+To add origins to an Office 365 CDN, you have to first connect to a tenant admin site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`. If you are connected to a different site and will try to manage tenant properties, you will get an error.
 
-Using the `-t, --type` option you can choose whether you want to manage the settings of
-the Public (default) or Private CDN. If you don't use the option, the command will use the Public CDN.
+Using the `-t, --type` option you can choose whether you want to manage the settings of the Public (default) or Private CDN. If you don't use the option, the command will use the Public CDN.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/cdn/cdn-origin-list.md
+++ b/docs/manual/docs/cmd/spo/cdn/cdn-origin-list.md
@@ -14,7 +14,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-t, --type [type]`|Type of CDN to manage. `Public|Private`. Default `Public`
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -23,13 +23,9 @@ Option|Description
 
 ## Remarks
 
-To list origins of a Office 365 CDN, you have to first connect to a tenant admin site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`.
-If you are connected to a different site and will try to manage tenant properties,
-you will get an error.
+To list origins of a Office 365 CDN, you have to first connect to a tenant admin site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`. If you are connected to a different site and will try to manage tenant properties, you will get an error.
 
-Using the `-t, --type` option you can choose whether you want to manage the settings of
-the Public (default) or Private CDN. If you don't use the option, the command will use the Public CDN.
+Using the `-t, --type` option you can choose whether you want to manage the settings of the Public (default) or Private CDN. If you don't use the option, the command will use the Public CDN.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/cdn/cdn-origin-remove.md
+++ b/docs/manual/docs/cmd/spo/cdn/cdn-origin-remove.md
@@ -16,7 +16,7 @@ Option|Description
 `-t, --type [type]`|Type of CDN to manage. `Public|Private`. Default `Public`
 `-r, --origin <origin>`|Origin to remove from the current CDN configuration
 `--confirm`|Don't prompt for confirming removal of a tenant property
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -25,13 +25,9 @@ Option|Description
 
 ## Remarks
 
-To remove an origin from an Office 365 CDN, you have to first connect to a tenant admin site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`.
-If you are connected to a different site and will try to manage tenant properties,
-you will get an error.
+To remove an origin from an Office 365 CDN, you have to first connect to a tenant admin site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`. If you are connected to a different site and will try to manage tenant properties, you will get an error.
 
-Using the `-t, --type` option you can choose whether you want to manage the settings of
-the Public (default) or Private CDN. If you don't use the option, the command will use the Public CDN.
+Using the `-t, --type` option you can choose whether you want to manage the settings of the Public (default) or Private CDN. If you don't use the option, the command will use the Public CDN.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/cdn/cdn-policy-list.md
+++ b/docs/manual/docs/cmd/spo/cdn/cdn-policy-list.md
@@ -14,7 +14,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-t, --type [type]`|Type of CDN to manage. `Public|Private`. Default `Public`
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -23,13 +23,9 @@ Option|Description
 
 ## Remarks
 
-To list the policies of an Office 365 CDN, you have to first connect to a tenant admin site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`.
-If you are connected to a different site and will try to manage tenant properties,
-you will get an error.
+To list the policies of an Office 365 CDN, you have to first connect to a tenant admin site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`. If you are connected to a different site and will try to manage tenant properties, you will get an error.
 
-Using the `-t, --type` option you can choose whether you want to manage the settings of
-the Public (default) or Private CDN. If you don't use the option, the command will use the Public CDN.
+Using the `-t, --type` option you can choose whether you want to manage the settings of the Public (default) or Private CDN. If you don't use the option, the command will use the Public CDN.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/cdn/cdn-policy-set.md
+++ b/docs/manual/docs/cmd/spo/cdn/cdn-policy-set.md
@@ -16,7 +16,7 @@ Option|Description
 `-t, --type [type]`|Type of CDN to manage. `Public|Private`. Default `Public`
 `-p, --policy <policy>`|CDN policy to configure. `IncludeFileExtensions|ExcludeRestrictedSiteClassifications`
 `-v, --value <value>`|Value for the policy to configure
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -25,13 +25,9 @@ Option|Description
 
 ## Remarks
 
-To set the policy of an Office 365 CDN, you have to first connect to a tenant admin site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`.
-If you are connected to a different site and will try to manage tenant properties,
-you will get an error.
+To set the policy of an Office 365 CDN, you have to first connect to a tenant admin site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`. If you are connected to a different site and will try to manage tenant properties, you will get an error.
 
-Using the `-t, --type` option you can choose whether you want to manage the settings of
-the Public (default) or Private CDN. If you don't use the option, the command will use the Public CDN.
+Using the `-t, --type` option you can choose whether you want to manage the settings of the Public (default) or Private CDN. If you don't use the option, the command will use the Public CDN.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/cdn/cdn-set.md
+++ b/docs/manual/docs/cmd/spo/cdn/cdn-set.md
@@ -15,7 +15,7 @@ Option|Description
 `--help`|output usage information
 `-e, --enabled <enabled>`|Set to true to enable CDN or to false to disable it. Valid values are true|false
 `-t, --type [type]`|Type of CDN to manage. `Public|Private`. Default `Public`
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -24,17 +24,11 @@ Option|Description
 
 ## Remarks
 
-To enable or disable an Office 365 CDN, you have to first connect to a tenant admin site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`.
-If you are connected to a different site and will try to manage tenant properties,
-you will get an error.
+To enable or disable an Office 365 CDN, you have to first connect to a tenant admin site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`. If you are connected to a different site and will try to manage tenant properties, you will get an error.
 
-Using the `-t, --type` option you can choose whether you want to manage the settings of
-the Public (default) or Private CDN. If you don't use the option, the command will use the Public CDN.
+Using the `-t, --type` option you can choose whether you want to manage the settings of the Public (default) or Private CDN. If you don't use the option, the command will use the Public CDN.
 
-Using the `-e, --enabled` option you can specify whether the given CDN type should be
-enabled or disabled. Use true to enable the specified CDN and false to
-disable it.
+Using the `-e, --enabled` option you can specify whether the given CDN type should be enabled or disabled. Use true to enable the specified CDN and false to disable it.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/connect.md
+++ b/docs/manual/docs/cmd/spo/connect.md
@@ -13,7 +13,7 @@ spo connect [options] <url>
 Option|Description
 ------|-----------
 `--help`|output usage information
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -25,18 +25,11 @@ Argument|Description
 
 ## Remarks
 
-Using the `spo connect` command, you can connect to any SharePoint Online site.
-Depending on the command you want to use, you might be required to connect
-to a SharePoint Online tenant admin site (suffixed with _-admin_,
-eg. _https://contoso-admin.sharepoint.com_) or a regular site.
+Using the `spo connect` command, you can connect to any SharePoint Online site. Depending on the command you want to use, you might be required to connect to a SharePoint Online tenant admin site (suffixed with _-admin_, eg. _https://contoso-admin.sharepoint.com_) or a regular site.
 
-The `spo connect` command uses device code OAuth flow with the standard
-Microsoft SharePoint Online Management Shell Azure AD application to connect
-to SharePoint Online.
+The `spo connect` command uses device code OAuth flow with the standard Microsoft SharePoint Online Management Shell Azure AD application to connect to SharePoint Online.
 
-When connecting to a SharePoint site, the `spo connect` command stores in memory
-the access token and the refresh token for the specified site. Both tokens are cleared from memory
-after exiting the CLI or by calling the [spo disconnect](connect.md) command.
+When connecting to a SharePoint site, the `spo connect` command stores in memory the access token and the refresh token for the specified site. Both tokens are cleared from memory after exiting the CLI or by calling the [spo disconnect](connect.md) command.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/customaction/customaction-add.md
+++ b/docs/manual/docs/cmd/spo/customaction/customaction-add.md
@@ -31,7 +31,7 @@ Option|Description
 `--scriptSrc [scriptSrc]`|Specifies a file that contains script to be executed. This attribute is only applicable when the Location attribute is set to ScriptLink
 `-c, --clientSideComponentId [clientSideComponentId]`|The Client Side Component Id (GUID) of the custom action
 `-p, --clientSideComponentProperties [clientSideComponentProperties]`|The Client Side Component Properties of the custom action. Specify values as a JSON string : `'{"testMessage":"Test message"}'`
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/customaction/customaction-get.md
+++ b/docs/manual/docs/cmd/spo/customaction/customaction-get.md
@@ -16,7 +16,7 @@ Option|Description
 `-i, --id <id>`|ID of the user custom action to retrieve information for
 `-u, --url <url>`|Url of the site or site collection to retrieve the custom action from
 `-s, --scope [scope]`|Scope of the custom action. Allowed values `Site|Web|All`. Default `All`
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -25,8 +25,7 @@ Option|Description
 
 ## Remarks
 
-To retrieve custom action, you have to first connect to a SharePoint Online site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
+To retrieve custom action, you have to first connect to a SharePoint Online site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/customaction/customaction-list.md
+++ b/docs/manual/docs/cmd/spo/customaction/customaction-list.md
@@ -15,7 +15,7 @@ Option|Description
 `--help`|output usage information
 `-u, --url <url>`|Url of the site or site collection to retrieve the custom action from
 `-s, --scope [scope]`|Scope of the custom action. Allowed values `Site|Web|All`. Default `All`
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -24,8 +24,7 @@ Option|Description
 
 ## Remarks
 
-To retrieve list of custom actions, you have to first connect to a SharePoint Online site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
+To retrieve list of custom actions, you have to first connect to a SharePoint Online site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/disconnect.md
+++ b/docs/manual/docs/cmd/spo/disconnect.md
@@ -13,7 +13,7 @@ spo disconnect [options]
 Option|Description
 ------|-----------
 `--help`|output usage information
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/externaluser/externaluser-list.md
+++ b/docs/manual/docs/cmd/spo/externaluser/externaluser-list.md
@@ -18,7 +18,7 @@ Option|Description
 `-i, --position [position]`|Use to specify the zero-based index of the position in the sorted collection of the first result to be returned
 `-s, --sortOrder [sortOrder]`|Specifies the sort results in Ascending or Descending order on the `SPOUser.Email` property should occur. Allowed values `asc|desc`. Default `asc`
 `-u, --siteUrl [siteUrl]`|Specifies the site to retrieve external users for. If no site is specified, the external users for all sites are returned
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/serviceprincipal/serviceprincipal-grant-list.md
+++ b/docs/manual/docs/cmd/spo/serviceprincipal/serviceprincipal-grant-list.md
@@ -19,7 +19,7 @@ spo sp grant list
 Option|Description
 ------|-----------
 `--help`|output usage information
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/serviceprincipal/serviceprincipal-grant-revoke.md
+++ b/docs/manual/docs/cmd/spo/serviceprincipal/serviceprincipal-grant-revoke.md
@@ -20,7 +20,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-i, --grantId <grantId>`|`ObjectId` of the permission grant to revoke
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/serviceprincipal/serviceprincipal-permissionrequest-approve.md
+++ b/docs/manual/docs/cmd/spo/serviceprincipal/serviceprincipal-permissionrequest-approve.md
@@ -20,7 +20,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-i, --requestId <requestId>`|ID of the permission request to approve
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/serviceprincipal/serviceprincipal-permissionrequest-deny.md
+++ b/docs/manual/docs/cmd/spo/serviceprincipal/serviceprincipal-permissionrequest-deny.md
@@ -20,7 +20,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-i, --requestId <requestId>`|ID of the permission request to deny
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/serviceprincipal/serviceprincipal-permissionrequest-list.md
+++ b/docs/manual/docs/cmd/spo/serviceprincipal/serviceprincipal-permissionrequest-list.md
@@ -19,7 +19,7 @@ spo sp permissionrequest list
 Option|Description
 ------|-----------
 `--help`|output usage information
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/serviceprincipal/serviceprincipal-set.md
+++ b/docs/manual/docs/cmd/spo/serviceprincipal/serviceprincipal-set.md
@@ -21,7 +21,7 @@ Option|Description
 `--help`|output usage information
 `-e, --enabled <enabled>`|Set to `true` to enable the service principal or to `false` to disable it. Valid values are `true|false`
 `--confirm`|Don't prompt for confirming enabling/disabling the service principal
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/site/site-add.md
+++ b/docs/manual/docs/cmd/spo/site/site-add.md
@@ -23,7 +23,7 @@ Option|Description
 `--allowFileSharingForGuestUsers`|Determines whether it's allowed to share file with guests (applies only to communication sites)
 `--siteDesign [siteDesign]`|Type of communication site to create. Allowed values `Topic|Showcase|Blank`, default `Topic`. When creating a communication site, specify either `siteDesign` or `siteDesignId` (applies only to communication sites)
 `--siteDesignId [siteDesignId]`|Id of the custom site design to use to create the site. When creating a communication site, specify either `siteDesign` or `siteDesignId` (applies only to communication sites)
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/site/site-appcatalog-add.md
+++ b/docs/manual/docs/cmd/spo/site/site-appcatalog-add.md
@@ -14,7 +14,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-u, --url <url>`|URL of the site collection where the app catalog should be added
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/site/site-appcatalog-remove.md
+++ b/docs/manual/docs/cmd/spo/site/site-appcatalog-remove.md
@@ -14,7 +14,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-u, --url <url>`|URL of the site collection containing the app catalog to disable
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/site/site-get.md
+++ b/docs/manual/docs/cmd/spo/site/site-get.md
@@ -14,7 +14,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-u, --url <url>`|URL of the site to retrieve information for
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/site/site-list.md
+++ b/docs/manual/docs/cmd/spo/site/site-list.md
@@ -15,7 +15,7 @@ Option|Description
 `--help`|output usage information
 `--type [type]`|type of modern sites to list. Allowed values `TeamSite|CommunicationSite`, default `TeamSite`
 `-f, --filter [filter]`|filter to apply when retrieving sites
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 

--- a/docs/manual/docs/cmd/spo/status.md
+++ b/docs/manual/docs/cmd/spo/status.md
@@ -13,15 +13,13 @@ spo status [options]
 Option|Description
 ------|-----------
 `--help`|output usage information
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
 ## Remarks
 
-If you are connected to a SharePoint Online, the spo status command
-will show you information about the site to which you are connected, the currently stored
-refresh and access token and the expiration date and time of the access token.
+If you are connected to a SharePoint Online, the spo status command will show you information about the site to which you are connected, the currently stored refresh and access token and the expiration date and time of the access token.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/storageentity/storageentity-get.md
+++ b/docs/manual/docs/cmd/spo/storageentity/storageentity-get.md
@@ -14,7 +14,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-k, --key <key>`|Name of the tenant property to retrieve
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -23,8 +23,7 @@ Option|Description
 
 ## Remarks
 
-To get details of a tenant property, you have to first connect to a SharePoint site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
+To get details of a tenant property, you have to first connect to a SharePoint site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
 
 Tenant properties are stored in the app catalog site associated with the site to which you are currently connected. When retrieving the specified tenant property, SharePoint will automatically find the associated app catalog and try to retrieve the property from it.
 

--- a/docs/manual/docs/cmd/spo/storageentity/storageentity-list.md
+++ b/docs/manual/docs/cmd/spo/storageentity/storageentity-list.md
@@ -14,7 +14,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-u, --appCatalogUrl <appCatalogUrl>`|URL of the app catalog site
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -23,8 +23,7 @@ Option|Description
 
 ## Remarks
 
-To list tenant properties, you have to first connect to a SharePoint site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
+To list tenant properties, you have to first connect to a SharePoint site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso.sharepoint.com`.
 
 Tenant properties are stored in the app catalog site. To list all tenant properties, you have to specify the absolute URL of the app catalog site. If you specify an incorrect URL, or the site at the given URL is not an app catalog site, no properties will be retrieved.
 

--- a/docs/manual/docs/cmd/spo/storageentity/storageentity-remove.md
+++ b/docs/manual/docs/cmd/spo/storageentity/storageentity-remove.md
@@ -16,7 +16,7 @@ Option|Description
 `-u, --appCatalogUrl <appCatalogUrl>`|URL of the app catalog site
 `-k, --key <key>`|Name of the tenant property to retrieve
 `--confirm`|Don't prompt for confirming removal of a tenant property
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -25,14 +25,9 @@ Option|Description
 
 ## Remarks
 
-To remove a tenant property, you have to first connect to a tenant admin site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`.
-If you are connected to a different site and will try to manage tenant properties,
-you will get an error.
+To remove a tenant property, you have to first connect to a tenant admin site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`. If you are connected to a different site and will try to manage tenant properties, you will get an error.
 
-Tenant properties are stored in the app catalog site associated with that tenant.
-To remove a property, you have to specify the absolute URL of the app catalog site.
-If you specify the URL of a site different than the app catalog, you will get an access denied error.
+Tenant properties are stored in the app catalog site associated with that tenant. To remove a property, you have to specify the absolute URL of the app catalog site. If you specify the URL of a site different than the app catalog, you will get an access denied error.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/storageentity/storageentity-set.md
+++ b/docs/manual/docs/cmd/spo/storageentity/storageentity-set.md
@@ -18,7 +18,7 @@ Option|Description
 `-v, --value <value>`|Value to set for the property
 `-d, --description [description]`|Description to set for the property (optional)
 `-c, --comment [comment]`|Comment to set for the property (optional)
-`-o, --output <output>`|Output type. `json|text`. Default `text`
+`-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
 
@@ -27,14 +27,9 @@ Option|Description
 
 ## Remarks
 
-To set a tenant property, you have to first connect to a tenant admin site using the
-[spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`.
-If you are connected to a different site and will try to manage tenant properties,
-you will get an error.
+To set a tenant property, you have to first connect to a tenant admin site using the [spo connect](../connect.md) command, eg. `spo connect https://contoso-admin.sharepoint.com`. If you are connected to a different site and will try to manage tenant properties, you will get an error.
 
-Tenant properties are stored in the app catalog site associated with that tenant.
-To set a property, you have to specify the absolute URL of the app catalog site.
-If you specify the URL of a site different than the app catalog, you will get an access denied error.
+Tenant properties are stored in the app catalog site associated with that tenant. To set a property, you have to specify the absolute URL of the app catalog site. If you specify the URL of a site different than the app catalog, you will get an access denied error.
 
 ## Examples
 

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -101,7 +101,7 @@ export default abstract class Command {
   public options(): CommandOption[] {
     return [
       {
-        option: '-o, --output <output>',
+        option: '-o, --output [output]',
         description: 'Output type. json|text. Default text',
         autocomplete: ['json', 'text']
       },


### PR DESCRIPTION
Originally, the `output` option was listed as required in the docs, while its usage was optional. Changed docs and command help to show it as optional.