### PR TITLE
Disabled normalizing vorpal args

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,9 @@ fs.realpath(__dirname, (err: NodeJS.ErrnoException, resolvedPath: string): void 
     process.exit();
   }
 
+  // disable linux-normalizing args to support JSON and XML values
+  vorpal.isCommandArgKeyPairNormalized = false;
+
   vorpal
     .command('version', 'Shows the current version of the CLI')
     .action(function (this: CommandInstance, args: any, cb: () => void) {

--- a/types/vorpal.d.ts
+++ b/types/vorpal.d.ts
@@ -5,6 +5,7 @@ interface Vorpal {
   delimiter: (delimiter: string) => Vorpal;
   exec: (command: string, callback?: () => void) => Promise<void>;
   find: (command: string) => VorpalCommand;
+  isCommandArgKeyPairNormalized: boolean;
   on: (event: string, handler: (data?: any) => void) => Vorpal;
   parse: (argv: string[], options?: { use: string }) => Vorpal;
   pipe: (onStdout: (stdout: any) => any) => Vorpal;


### PR DESCRIPTION
Disabled normalizing vorpal args to allow using complex values such as JSON or XML strings