### PR TITLE
Fixed 'spo cdn origin add' example, origin argument is r (not o)

### DIFF
--- a/src/o365/spo/commands/cdn/cdn-origin-add.ts
+++ b/src/o365/spo/commands/cdn/cdn-origin-add.ts
@@ -160,7 +160,7 @@ class SpoCdnOriginAddCommand extends SpoCommand {
   Examples:
   
     Add ${chalk.grey('*/CDN')} to the list of origins of the Public CDN
-      ${chalk.grey(config.delimiter)} ${commands.CDN_ORIGIN_ADD} -t Public -o */CDN
+      ${chalk.grey(config.delimiter)} ${commands.CDN_ORIGIN_ADD} -t Public -r */CDN
 
   More information:
 


### PR DESCRIPTION
Fixed 'spo cdn origin add' example, origin argument is r (not o)