### PR TITLE
Update tsconfig.json for TypeScript 2.7 strict

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     /* Strict Type-Checking Options */
     "strict": true,                            /* Enable all strict type-checking options. */
     "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "strictPropertyInitialization": false ,         /* http://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "noImplicitThis": false,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */


### PR DESCRIPTION
strictPropertyInitialization in TypeScript 2.7 breaks the compile of the project as is. Setting this to false mimics the 2.6.x compilation rules. http://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html 