### PR TITLE
Propertybag remove typo fixes

### DIFF
--- a/docs/manual/docs/cmd/spo/propertybag/propertybag-remove.md
+++ b/docs/manual/docs/cmd/spo/propertybag/propertybag-remove.md
@@ -15,7 +15,7 @@ Option|Description
 `--help`|output usage information
 `-u, --webUrl <webUrl>`|The URL of the site from which the property should be removed
 `-k, --key <key>`|Key of the property to be removed. Case-sensitive
-`-f, --folder [folder]`|Server- or site-relative URL of the folder from which to remove the property bag value
+`-f, --folder [folder]`|Site-relative URL of the folder from which to remove the property bag value
 `--confirm`|Don't prompt for confirming removal of property bag value
 `-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnp/office365-cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnp/office365-cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Manage Microsoft Office 365 on any platform",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/o365/spo/commands/propertybag/propertybag-remove.spec.ts
+++ b/src/o365/spo/commands/propertybag/propertybag-remove.spec.ts
@@ -209,7 +209,7 @@ describe(commands.PROPERTYBAG_REMOVE, () => {
     });
   });
 
-  it('should user custom action removed successfully (verbose) without prompting with confirmation argument', (done) => {
+  it('should property be removed successfully (verbose) without prompting with confirmation argument', (done) => {
     stubAllPostRequests();
 
     auth.site = new Site();
@@ -235,7 +235,7 @@ describe(commands.PROPERTYBAG_REMOVE, () => {
     });
   });
 
-  it('should prompt before removing custom action when confirmation argument not passed', (done) => {
+  it('should prompt before removing property when confirmation argument not passed', (done) => {
     auth.site = new Site();
     auth.site.connected = true;
     auth.site.url = 'https://contoso-admin.sharepoint.com';
@@ -263,7 +263,7 @@ describe(commands.PROPERTYBAG_REMOVE, () => {
     });
   });
 
-  it('should abort custom action remove when prompt not confirmed', (done) => {
+  it('should abort property remove when prompt not confirmed', (done) => {
     const postCallsSpy: sinon.SinonStub = stubAllPostRequests();
 
     auth.site = new Site();
@@ -289,7 +289,7 @@ describe(commands.PROPERTYBAG_REMOVE, () => {
     });
   });
 
-  it('should remove custom action when prompt confirmed', (done) => {
+  it('should remove property when prompt confirmed', (done) => {
     const postCallsSpy: sinon.SinonStub = stubAllPostRequests();
     const removePropertySpy = sinon.spy((command as any), 'removeProperty');
 

--- a/src/o365/spo/commands/propertybag/propertybag-remove.ts
+++ b/src/o365/spo/commands/propertybag/propertybag-remove.ts
@@ -171,7 +171,7 @@ class SpoPropertyBagRemoveCommand extends SpoPropertyBagBaseCommand {
       },
       {
         option: '-f, --folder [folder]',
-        description: 'Server- or site-relative URL of the folder from which to remove the property bag value',
+        description: 'Site-relative URL of the folder from which to remove the property bag value',
       },
       {
         option: '--confirm',
@@ -222,7 +222,7 @@ class SpoPropertyBagRemoveCommand extends SpoPropertyBagBaseCommand {
       ${chalk.grey(config.delimiter)} ${commands.PROPERTYBAG_REMOVE} --webUrl https://contoso.sharepoint.com/sites/test --key key1 --folder '/Shared Documents'
     
     Removes property bag value located in folder in site document library ${chalk.grey('https://contoso.sharepoint.com/sites/test')}
-      ${chalk.grey(config.delimiter)} ${commands.PROPERTYBAG_REMOVE} --webUrl https://contoso.sharepoint.com/sites/test --k key1 --folder '/Shared Documents/MyFolder'
+      ${chalk.grey(config.delimiter)} ${commands.PROPERTYBAG_REMOVE} --webUrl https://contoso.sharepoint.com/sites/test --key key1 --folder '/Shared Documents/MyFolder'
 
     Removes the value of the ${chalk.grey('key1')} property from the property bag located in site list ${chalk.grey('https://contoso.sharepoint.com/sites/test')}
       ${chalk.grey(config.delimiter)} ${commands.PROPERTYBAG_REMOVE} --webUrl https://contoso.sharepoint.com/sites/test --key key1 --folder /Lists/MyList


### PR DESCRIPTION
Typo fixes
'Server-relative' removed from the `--folder` option description.