### PR TITLE
Updated the folder desc of propertybag get and list

### DIFF
--- a/docs/manual/docs/cmd/spo/propertybag/propertybag-get.md
+++ b/docs/manual/docs/cmd/spo/propertybag/propertybag-get.md
@@ -15,7 +15,7 @@ Option|Description
 `--help`|output usage information
 `-u, --webUrl <webUrl>`|The URL of the site from which the property bag value should be retrieved
 `-k, --key <key>`|Key of the property for which the value should be retrieved. Case-sensitive
-`-f, --folder [folder]`|Server- or site-relative URL of the folder from which to retrieve property bag value. Case-sensitive
+`-f, --folder [folder]`|Site-relative URL of the folder from which to retrieve property bag value. Case-sensitive
 `-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging

--- a/docs/manual/docs/cmd/spo/propertybag/propertybag-list.md
+++ b/docs/manual/docs/cmd/spo/propertybag/propertybag-list.md
@@ -14,7 +14,7 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-u, --webUrl <webUrl>`|The URL of the site from which the property bag value should be retrieved
-`-f, --folder [folder]`|Server- or site-relative URL of the folder from which to retrieve property bag value. Case-sensitive
+`-f, --folder [folder]`|Site-relative URL of the folder from which to retrieve property bag value. Case-sensitive
 `-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging

--- a/src/o365/spo/commands/propertybag/propertybag-get.ts
+++ b/src/o365/spo/commands/propertybag/propertybag-get.ts
@@ -113,7 +113,7 @@ class SpoPropertyBagGetCommand extends SpoPropertyBagBaseCommand {
       },
       {
         option: '-f, --folder [folder]',
-        description: 'Server- or site-relative URL of the folder from which to retrieve property bag value. Case-sensitive',
+        description: 'Site-relative URL of the folder from which to retrieve property bag value. Case-sensitive',
       }
     ];
 

--- a/src/o365/spo/commands/propertybag/propertybag-list.ts
+++ b/src/o365/spo/commands/propertybag/propertybag-list.ts
@@ -103,7 +103,7 @@ class SpoPropertyBagListCommand extends SpoPropertyBagBaseCommand {
       },
       {
         option: '-f, --folder [folder]',
-        description: 'Server- or site-relative URL of the folder from which to retrieve property bag value. Case-sensitive',
+        description: 'Site-relative URL of the folder from which to retrieve property bag value. Case-sensitive',
       }
     ];
 


### PR DESCRIPTION
Removes 'server-relative' text from the `--folder` option description for both propertybag get and list commands